### PR TITLE
test(slack-bot): add tests for slack bot

### DIFF
--- a/packages/slack-bot/knowledge_base.py
+++ b/packages/slack-bot/knowledge_base.py
@@ -15,6 +15,20 @@ bucket_embeddings_file = os.environ.get("GCP_STORAGE_EMBEDDING_FILE_NAME")
 embeddings_subscription = os.environ.get("GCP_EMBEDDING_SUBSCRIPTION")
 local_embeddings_file = ".cache/embeddings.csv"
 
+is_module_initialized = False
+df = None
+
+
+def initialize_module_if_necessary():
+    global is_module_initialized
+    global df
+
+    if is_module_initialized == False:
+        is_module_initialized = True
+        make_cache_folder()
+        df = get_embeddings_file()
+        subscribe_to_embedding_changes()
+
 
 def make_cache_folder():
     if not os.path.exists(".cache"):
@@ -138,9 +152,5 @@ def answer_question(
 
 
 def get_answer(question):
+    initialize_module_if_necessary()
     return answer_question(df, question=question, debug=True)
-
-
-make_cache_folder()
-df = get_embeddings_file()
-subscribe_to_embedding_changes()

--- a/packages/slack-bot/test.py
+++ b/packages/slack-bot/test.py
@@ -1,26 +1,22 @@
 import unittest
 from unittest.mock import MagicMock
 import openai
-from google.cloud import storage
+import knowledge_base as knowledge_base
 
 
-# Google cloud storage mocks
-class GoogleCloudStorageMock:
-    def bucket(bucket_name, _):
-        return GoogleCloudBucketMock()
+# Create .cache/embeddings.csv mock
+def createEmbeddingFile():
+    embeddingsFileMock = (
+        ",text,n_tokens,embeddings\n"
+        '0,"NearForm is a software development company.",500,"[0.017733527347445488, -0.01051256712526083, -0.004159081261605024, -0.037195149809122086, -0.029185574501752853]"'
+    )
+    with open("./.cache/embeddings.csv", "w") as f:
+        f.write(embeddingsFileMock)
 
 
-class GoogleCloudBucketMock:
-    def blob(file_name, _):
-        return GoogleCloudBlobMock()
-
-
-class GoogleCloudBlobMock:
-    def download_to_filename(destination, _):
-        return
-
-
-storage.Client = MagicMock(return_value=GoogleCloudStorageMock())
+# Mock out some internal methods
+knowledge_base.subscribe_to_embedding_changes = MagicMock()
+knowledge_base.download_csv_from_bucket_to_path = MagicMock(side_effect=createEmbeddingFile())
 
 
 # OPEN AI mocks
@@ -42,18 +38,6 @@ openAIEmbeddingsResponseMock = {
 openAICompletionResponseMock = {
     "choices": [{"message": {"content": "Answer mock"}}],
 }
-
-embeddingsFileMock = (
-    ",text,n_tokens,embeddings\n"
-    '0,"NearForm is a software development company.",500,"[0.017733527347445488, -0.01051256712526083, -0.004159081261605024, -0.037195149809122086, -0.029185574501752853]"'
-)
-
-# Create .cache/embeddings.csv mock
-with open("./.cache/embeddings.csv", "w") as f:
-    f.write(embeddingsFileMock)
-
-# Imported here since we need to mock dependencies before module execution
-import knowledge_base as knowledge_base
 
 
 class TestAnswer(unittest.TestCase):


### PR DESCRIPTION
Closes: #67

This test also refactors `knowledge_base.py` by moving the module initialization operations in a `initialize_module_if_necessary` function triggered by `get_answer`.

Since the module is meant to be deployed as a lamba it shouldn't affect startup time.