### PR TITLE
feat: limit the answers only to received context

### DIFF
--- a/packages/slack-bot/knowledge_base.py
+++ b/packages/slack-bot/knowledge_base.py
@@ -157,8 +157,6 @@ def answer_question(
         return ""
 
 
-initialize_module_if_necessary()
-
-
 def get_answer(question):
+    initialize_module_if_necessary()
     return answer_question(df, question=question, debug=True)


### PR DESCRIPTION
Restrict the context to receive only NF related answers. Also moved the initialization call outside `get_answer`.

~~@toomuchdesign what do you think about the last point? If we call `initialize_module_if_necessary` inside `get_answer` it will break on the first question, since the embeddings is not there (locally tested).~~ Excluded from this PR.

Closes #106 .