### PR TITLE
fix:  removed --snapshot flag from crawler test script

### DIFF
--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
-    "test": "cross-env NODE_OPTIONS=--loader=esmock tap --snapshot",
+    "test": "cross-env NODE_OPTIONS=--loader=esmock tap",
     "lint": "eslint .",
     "start": "node ./src/index.js"
   },


### PR DESCRIPTION
As the title says. I forgot it when I fixed the snapshot test in my last PR.