### PR TITLE
fix: send ack to pubsub as the first operation

### DIFF
--- a/packages/slack-bot/src/getAnswer.js
+++ b/packages/slack-bot/src/getAnswer.js
@@ -179,8 +179,6 @@ async function getAnswer({
     model
   })
 
-  console.timeEnd('completiomn')
-
   return response.data.choices[0].message.content.trim()
 }
 


### PR DESCRIPTION
As the title says, to avoid receiving multiple messages from the topic.