### PR TITLE
refactor: reshape createChatCompletion assistant instruction payload

### DIFF
--- a/packages/slack-bot/src/getAnswer.js
+++ b/packages/slack-bot/src/getAnswer.js
@@ -164,34 +164,35 @@ async function getAnswer({
     messages: [
       { role: 'system', content: 'You are a helpful assistant' },
       {
-        role: 'assistant',
-        content:
-          "You are providing information to NearForm employees asking questions about NearForm's knowledge base."
-      },
-      {
-        role: 'assistant',
-        content: `This is NearForm's knowledge base:\n\n${context.join(
+        role: 'user',
+        content: `The call the following set of information <CONTEXT>:\n\n${context.join(
           '\n\n###\n\n'
         )}`
       },
       {
-        role: 'assistant',
-        content:
-          "You can only produce answers based on NearForm's knowledge base provided before. You must not use any other information source."
-      },
-      {
-        role: 'assistant',
-        content:
-          'If the question is about NearForm but you cannot find an answer in the provided knowledge base you will answer: "I\'m sorry I could not find relevant information."'
-      },
-      {
-        role: 'assistant',
-        content:
-          'If a question is not related to NearForm you will answer "I\'m sorry but I can only provide answers to questions related to NearForm."'
+        role: 'user',
+        content: `I'm a NearForm employee and I'm going to ask questions about <CONTEXT> or NearForm.`
       },
       {
         role: 'user',
-        content: question
+        content: `If question is NOT related to <CONTEXT> or NearForm respond with: "I'm sorry but I can only provide answers to questions related to NearForm."`
+      },
+      {
+        role: 'user',
+        content: `If there is NO relevant information in <CONTEXT> to answer the question, then briefly apologize with the user.`
+      },
+      {
+        role: 'user',
+        content: `If you provide an answer, use only the information existing in <CONTEXT>. You must not use any other source of information."`
+      },
+      {
+        role: 'user',
+        content: `If you provide an answer you MUST not mention the source of the information nor <CONTEXT>. Provide just the expected information.`
+      },
+      // @TODO add here last provided answers (as assistant) to enable a conversational interaction
+      {
+        role: 'user',
+        content: `Question: ${question}`
       }
     ],
     temperature: 0,

--- a/packages/slack-bot/test/getAnswer.test.js
+++ b/packages/slack-bot/test/getAnswer.test.js
@@ -68,13 +68,15 @@ tap.test('getAnswer', async t => {
       }
     )
 
-    const actual = await getAnswer({ question: 'Question' })
-    const expected = 'Actual chat response'
-    tt.equal(actual, expected)
+    const question = 'This is the question'
+
+    const actualAnswer = await getAnswer({ question })
+    const expectedAnswer = 'Actual chat response'
+    tt.equal(actualAnswer, expectedAnswer)
 
     sinon.assert.calledOnceWithExactly(createEmbeddingMock, {
       model: 'text-embedding-ada-002',
-      input: 'Question'
+      input: question
     })
 
     const expectedContext = ['Content page 1', 'Content page 2']
@@ -82,34 +84,35 @@ tap.test('getAnswer', async t => {
       messages: [
         { role: 'system', content: 'You are a helpful assistant' },
         {
-          role: 'assistant',
-          content:
-            "You are providing information to NearForm employees asking questions about NearForm's knowledge base."
-        },
-        {
-          role: 'assistant',
-          content: `This is NearForm knowledge base:\n\n${expectedContext.join(
+          role: 'user',
+          content: `The call the following set of information <CONTEXT>:\n\n${expectedContext.join(
             '\n\n###\n\n'
           )}`
         },
         {
-          role: 'assistant',
-          content:
-            "You can only produce answers based on NearForm's knowledge base provided before. You must not use any other information source."
-        },
-        {
-          role: 'assistant',
-          content:
-            'If the question is about NearForm but you cannot find an answer in the provided knowledge base you will answer: "I\'m sorry I could not find relevant information."'
-        },
-        {
-          role: 'assistant',
-          content:
-            'If a question is not related to NearForm you will answer "I\'m sorry but I can only provide answers to questions related to NearForm."'
+          role: 'user',
+          content: `I'm a NearForm employee and I'm going to ask questions about <CONTEXT> or NearForm.`
         },
         {
           role: 'user',
-          content: 'Question'
+          content: `If question is NOT related to <CONTEXT> or NearForm respond with: "I'm sorry but I can only provide answers to questions related to NearForm."`
+        },
+        {
+          role: 'user',
+          content: `If there is NO relevant information in <CONTEXT> to answer the question, then briefly apologize with the user.`
+        },
+        {
+          role: 'user',
+          content: `If you provide an answer, use only the information existing in <CONTEXT>. You must not use any other source of information."`
+        },
+        {
+          role: 'user',
+          content: `If you provide an answer you MUST not mention the source of the information nor <CONTEXT>. Provide just the expected information.`
+        },
+        // @TODO add here last provided answers (as assistant) to enable a conversational interaction
+        {
+          role: 'user',
+          content: `Question: ${question}`
         }
       ],
       temperature: 0,


### PR DESCRIPTION
This PR refactors `createChatCompletion` by splitting assistant instruction sentences into separate pre-configured conversation blocks (see [createChatCompletion api docs](https://platform.openai.com/docs/guides/chat/introduction)).

It also adds a specific instruction to handle the case of a question being about NF but lacking from currently provided knowledge base.

Closes #134