### PR TITLE
[POC] feat: provide createChatCompletion with previous chat messages

### DIFF
--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -17,7 +17,30 @@ const expressApp = expressReceiver.app
 
 app.event('message', async ({ event, client }) => {
   try {
-    const answer = await getAnswer({ question: event.text })
+    const slackConversationHistory = await client.conversations.history({
+      channel: event.channel,
+      limit: 4
+    })
+
+    const conversationHistory = slackConversationHistory.messages.map(
+      ({ client_msg_id, text }) => {
+        if (client_msg_id) {
+          return {
+            role: 'user',
+            content: text
+          }
+        }
+        return {
+          role: 'assistant',
+          content: text
+        }
+      }
+    )
+
+    const answer = await getAnswer({
+      question: event.text,
+      conversationHistory
+    })
     await client.chat.postMessage({
       channel: event.channel,
       text: answer

--- a/packages/slack-bot/src/getAnswer.js
+++ b/packages/slack-bot/src/getAnswer.js
@@ -137,10 +137,23 @@ async function createContext({
   return context
 }
 
+/**
+ * @param {Object} args
+ * @param {string} args.question
+ * @param {({role: "user", content: text} | {role: "assistant", content: text})[]} [args.conversationHistory]
+ * @param {{"": string; n_tokens: number; embeddings: number[]; text: string;}[]} [args.dataSet]
+ * @param {string} [args.model]
+ * @param {number} [args.maxLength]
+ * @param {string} [args.embeddingModel]
+ * @param {number} [args.maxTokens]
+ * @param {string} [args.stopSequence]
+ * @returns string
+ */
 async function getAnswer({
+  question,
+  conversationHistory = [],
   dataSet: customDataSet,
   model = 'gpt-4',
-  question = 'What is NearForm?',
   maxLength = 1800,
   embeddingModel = defaultEmbeddingModel,
   maxTokens = 300,
@@ -189,7 +202,7 @@ async function getAnswer({
         role: 'user',
         content: `If you provide an answer you MUST not mention the source of the information nor <CONTEXT>. Provide just the expected information.`
       },
-      // @TODO add here last provided answers (as assistant) to enable a conversational interaction
+      ...conversationHistory,
       {
         role: 'user',
         content: `Question: ${question}`


### PR DESCRIPTION
This PR queries Slack api to fetch the last few user/bot conversation messages and provide those to [openai `createChatCompletion` api](https://platform.openai.com/docs/api-reference/chat/create
) as an attempt to not lose the previous questions context.

## What didn't work

It technically works, but it doesn't achieve the desired goal since `createChatCompletion` is provided with a different knowledge base context on each request (since knowledge base context is a subset of the original knowledge base filtered on the current question).

In other words: a question formulated by relying on a previous question context will usually generate a very poor context to call `createChatCompletion` with.

eg:

- Q: How can I book a flight?
- A: In order to book a flight do this and that
- Q: Do I have a max budget? <--the context generated here won't be related to travel booking policies.

## What could we do next

A possible extra step could consist of using the previous chat messages not only to call `createChatCompletion` but to also generate the context embeddings in `createContext`. This could bring unexpected noise in the generated context and therefore a minor relevance of the generated answers.

A move in this direction should therefore be properly audited.

Implementation attempt of #161