### PR TITLE
feat(261): improve crawler - enhance prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,25 @@ Add the following values in an `.env` file (needed for local development). You c
 display_information:
   name: NearForm Know-It-All
   description: A chatbot that can answer questions on thenearformway.com content
-  background_color: '#2165e3'
+  background_color: "#2165e3"
 features:
   bot_user:
     display_name: NearForm Know-It-All
     always_online: true
+  slash_commands:
+    - command: /test
+      url: <slack-bot-url>
+      description: Test
+      usage_hint: Test
+      should_escape: false
 oauth_config:
   scopes:
     bot:
       - chat:write
+      - commands
       - im:history
+      - users.profile:read
+      - users:read
 settings:
   event_subscriptions:
     request_url: <slack-bot-url>

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ features:
     display_name: NearForm Know-It-All
     always_online: true
   slash_commands:
-    - command: /test
+    - command: /know-it-all
       url: <slack-bot-url>
-      description: Test
-      usage_hint: Test
+      description: A chatbot that can answer questions on thenearformway.com content
+      usage_hint: Ask a question about the NearForm Way
       should_escape: false
 oauth_config:
   scopes:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In order to run the slack bot locally you'll need to install `ngrok` globally on
 
 #### Environment variables
 
-Add the following values in an `.env` file (needed for local development). You can access these from Bitwarden, within the Hub content folder.
+Add the following values in an `.env` file (needed for local development):
 
 | Env var                         |                                         |
 | ------------------------------- | --------------------------------------- |
@@ -63,7 +63,7 @@ Add the following values in an `.env` file (needed for local development). You c
 
 #### Environment variables
 
-Add the following values in an `.env` file (needed for local development). You can access these from Bitwarden, within the Hub content folder.
+Add the following values in an `.env` file (needed for local development):
 
 | Env var                           |                                      |
 | --------------------------------- | ------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In order to run the slack bot locally you'll need to install `ngrok` globally on
 
 #### Environment variables
 
-Add the following values in an `.env` file (needed for local development):
+Add the following values in an `.env` file (needed for local development). You can access these from Bitwarden, within the Hub content folder.
 
 | Env var                         |                                         |
 | ------------------------------- | --------------------------------------- |
@@ -63,7 +63,7 @@ Add the following values in an `.env` file (needed for local development):
 
 #### Environment variables
 
-Add the following values in an `.env` file (needed for local development):
+Add the following values in an `.env` file (needed for local development). You can access these from Bitwarden, within the Hub content folder.
 
 | Env var                           |                                      |
 | --------------------------------- | ------------------------------------ |
@@ -110,7 +110,7 @@ settings:
 
 #### Environment variables
 
-Add the following values in an `.env` file (needed for local development):
+Add the following values in an `.env` file (needed for local development). You can access these from Bitwarden, within the Hub content folder, except for the specific values you are using based on your setup from Slack.
 
 | Env var                           |                                                                            |
 | --------------------------------- | -------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ settings:
 
 #### Environment variables
 
-Add the following values in an `.env` file (needed for local development). You can access these from Bitwarden, within the Hub content folder, except for the specific values you are using based on your setup from Slack.
+Add the following values in an `.env` file (needed for local development):
 
 | Env var                           |                                                                            |
 | --------------------------------- | -------------------------------------------------------------------------- |

--- a/packages/crawler/src/crawl.js
+++ b/packages/crawler/src/crawl.js
@@ -6,13 +6,14 @@ import { upload, createCsv } from './utils.js'
 
 const { GCP_STORAGE_BUCKET_NAME, GCP_STORAGE_SCRAPED_FILE_NAME } = process.env
 
-export const crawl = () => {
-  return fetchData()
-    .then(createCsv)
-    .then(csv => fs.writeFile(GCP_STORAGE_SCRAPED_FILE_NAME, csv))
-    .then(upload(GCP_STORAGE_BUCKET_NAME, GCP_STORAGE_SCRAPED_FILE_NAME))
-    .catch(err => {
-      console.error(err)
-      process.exit(1)
-    })
+export const crawl = async () => {
+  try {
+    const data = await fetchData()
+    const csvData = await createCsv(data)
+    await fs.writeFile(GCP_STORAGE_SCRAPED_FILE_NAME, csvData)
+    await upload(GCP_STORAGE_BUCKET_NAME, GCP_STORAGE_SCRAPED_FILE_NAME)
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
 }

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -17,13 +17,28 @@ const expressApp = expressReceiver.app
 
 app.event('message', async ({ event, client }) => {
   try {
-    const answer = await getAnswer({ question: event.text })
+    let user = null
+    try {
+      const clientReq = await client.users.info({
+        user: event.user,
+        include_locale: true
+      })
+      user = clientReq.user
+    } catch (error) {
+      console.error('error', error)
+    }
+
+    const answer = await getAnswer({
+      question: event.text,
+      locale: user?.locale
+    })
+
     await client.chat.postMessage({
       channel: event.channel,
       text: answer
     })
   } catch (error) {
-    console.error(error)
+    console.error('message event error', error)
   }
 })
 

--- a/packages/slack-bot/src/getAnswer.js
+++ b/packages/slack-bot/src/getAnswer.js
@@ -149,17 +149,8 @@ async function getAnswer({
       },
       {
         role: 'user',
-        content: `My current locale is ${locale} so please bear in mind I may be needing for information related to my country.`
+        content: `My current locale is ${locale} so factor this in to the context of my questions so that information you provide relevant to my country.`
       },
-      // Handle question about protected pages
-      // {
-      //   role: 'assistant',
-      //   content: `If question is related to one of the following subjects, explain that you cannot provide an answer since the the answer could change depending on the country:\n${protectedPagesList}`
-      // },
-      // {
-      //   role: 'assistant',
-      //   content: `If question is NOT related to <CONTEXT> or NearForm respond with: "I'm sorry but I can only provide answers to questions related to NearForm."`
-      // },
       {
         role: 'assistant',
         content: `If there is NO relevant information in <CONTEXT> to answer the question, then briefly apologize with the user.`

--- a/packages/slack-bot/src/getAnswer.js
+++ b/packages/slack-bot/src/getAnswer.js
@@ -7,7 +7,6 @@ import {
   distancesFromEmbeddings,
   isLocalEnvironment
 } from './utils.js'
-import { protectedPagesList } from './constants.js'
 
 const defaultEmbeddingModel = 'text-embedding-ada-002'
 const projectId = process.env.GCP_PROJECT_ID
@@ -118,7 +117,8 @@ async function getAnswer({
   maxLength = 1800,
   embeddingModel = defaultEmbeddingModel,
   maxTokens = 300,
-  stopSequence
+  stopSequence,
+  locale = 'en-IE'
 }) {
   await initializationPromise
   const dataSet = customDataSet ?? defaultDataSet
@@ -147,15 +147,19 @@ async function getAnswer({
         role: 'user',
         content: `I'm a NearForm employee and I'm going to ask questions about <CONTEXT> or NearForm.`
       },
+      {
+        role: 'user',
+        content: `My current locale is ${locale} so please bear in mind I may be needing for information related to my country.`
+      },
       // Handle question about protected pages
-      {
-        role: 'assistant',
-        content: `If question is related to one of the following subjects, explain that you cannot provide an answer since the the answer could change depending on the country:\n${protectedPagesList}`
-      },
-      {
-        role: 'assistant',
-        content: `If question is NOT related to <CONTEXT> or NearForm respond with: "I'm sorry but I can only provide answers to questions related to NearForm."`
-      },
+      // {
+      //   role: 'assistant',
+      //   content: `If question is related to one of the following subjects, explain that you cannot provide an answer since the the answer could change depending on the country:\n${protectedPagesList}`
+      // },
+      // {
+      //   role: 'assistant',
+      //   content: `If question is NOT related to <CONTEXT> or NearForm respond with: "I'm sorry but I can only provide answers to questions related to NearForm."`
+      // },
       {
         role: 'assistant',
         content: `If there is NO relevant information in <CONTEXT> to answer the question, then briefly apologize with the user.`

--- a/packages/slack-bot/test/getAnswer.test.js
+++ b/packages/slack-bot/test/getAnswer.test.js
@@ -69,6 +69,7 @@ tap.test('getAnswer', async t => {
     )
 
     const question = 'This is the question'
+    const locale = 'en-IE'
 
     const actualAnswer = await getAnswer({ question })
     const expectedAnswer = 'Actual chat response'
@@ -94,23 +95,8 @@ tap.test('getAnswer', async t => {
           content: `I'm a NearForm employee and I'm going to ask questions about <CONTEXT> or NearForm.`
         },
         {
-          role: 'assistant',
-          content: `If question is related to one of the following subjects, explain that you cannot provide an answer since the the answer could change depending on the country:
-- Annual Leave policies
-- Employee Bonus Plan
-- Remote Working Support policies
-- Sabbatical
-- Marriage leave
-- Compassionate Leave
-- COVID 19 Support
-- Jury Service
-- Public Holidays
-- Sick Leave
-- Probation period`
-        },
-        {
-          role: 'assistant',
-          content: `If question is NOT related to <CONTEXT> or NearForm respond with: "I'm sorry but I can only provide answers to questions related to NearForm."`
+          role: 'user',
+          content: `My current locale is ${locale} so factor this in to the context of my questions so that information you provide relevant to my country.`
         },
         {
           role: 'assistant',


### PR DESCRIPTION
This PR resolves nearform/hub-draft-issues#261 and completes the following:

- Adds a note that environment variables are available in Bitwarden
- Small refactor in the `crawler` to ensure promises are correctly executed to proceed to the next step
    - This was breaking when starting fresh to the project as the `scraped.csv` file did not exist, as its creation was not suitably being awaited
- Updates README with extra scope required in the Slack Bot to read users profile data
- Retrieves user profile information, including the users locale (set within the Slack app they are using)
- Removes the need to protect certain pages from being used in the conversations context
- Updates the conversation, providing the users locale in to it to provide a steer to provide more relevant information
- Also added the ability for the Slack bot to be called through a slash command - rather than being forced to be used within user:bot private conversation
