### PR TITLE
ci: set slackbot CPU explicitly to satisfy the concurrency constraint

### DIFF
--- a/.github/workflows/deploy-step.yml
+++ b/.github/workflows/deploy-step.yml
@@ -135,6 +135,7 @@ jobs:
           gcloud beta functions deploy slackbot
           --runtime nodejs24 
           --memory=512MB
+          --cpu=1
           --min-instances=1
           --max-instances=5
           --concurrency=5


### PR DESCRIPTION
Fixes #980

The production deploy fails at the `Deploy slackBot to Cloud Run` step:

```
ERROR: (gcloud.beta.functions.deploy) ResponseError: status=[400]
spec.template.spec.containers.resources.limits.cpu: Invalid value specified for cpu.
Total cpu < 1 is not supported with concurrency > 1.
```

That step passes `--memory=512MB` and `--concurrency=5` but no `--cpu`, so gcloud derives the CPU from the memory setting. The derived value is below one vCPU, which Cloud Run rejects when concurrency is greater than 1.

The intended state was never wrong: every revision of this service for the past year runs at `cpu=1`. This states that value explicitly rather than leaving it to be derived from an unrelated setting, so it is no change to what production actually runs.

Because the job fails at that step, no new revision is created and the two steps after it, the startup probe configuration and the embeddings function deploy, never run.

## Verification

The workflow still parses, and the folded scalar for that step still collapses to a single command line with no embedded newlines:

```
gcloud beta functions deploy slackbot --runtime nodejs24 --memory=512MB --cpu=1 --min-instances=1 --max-instances=5 --concurrency=5 --region=europe-west1 --gen2 --source=./packages/slack-bot ...
```

## Not changed

The `embedding-creation` step sets no `--concurrency`, so the event-driven default of 1 makes a sub-1 CPU legal there and it needs no equivalent flag. It is worth noting it is untested against this failure, since the job never reached it.
