### PR TITLE
fix: ignore non-user message events, and make file and voice questions work

### DIFF
--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -6,6 +6,7 @@ import { transcribe } from './utils.js'
 import {
   carriesQuestion,
   hasFileAttachment,
+  hasQuestionText,
   isPlainUserMessage
 } from './messageEvents.js'
 import summarize from './summarize.js'
@@ -42,6 +43,11 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
 
 const errorResponse =
   'It appears I have run into an issue looking up an answer for you. Please try again'
+
+// Nothing went wrong on our side, so the generic failure above would be
+// misleading as well as unhelpful.
+const unintelligibleAudioResponse =
+  'I could not make out any words in that recording. Please try again, or type your question instead'
 
 app.event('message', async ({ event, client }) => {
   console.log('message event', event)
@@ -94,6 +100,17 @@ app.event('message', async ({ event, client }) => {
             text: `Give me a moment whilst I check for you. You asked: "${transcribedResponse.trim()}"`,
             thread_ts: event.ts
           })
+        } else if (!hasQuestionText(event)) {
+          // The audio yielded no words and there is nothing typed to fall back
+          // on, so there is no question to look up. Say so, rather than asking
+          // getAnswer for an answer to nothing and reporting its failure as
+          // ours.
+          await client.chat.postMessage({
+            channel: event.channel,
+            text: unintelligibleAudioResponse,
+            thread_ts: event.ts
+          })
+          return
         }
       } catch (err) {
         console.error('transcription error', err)

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -55,6 +55,11 @@ const unintelligibleAudioResponse =
 const unreadableAttachmentResponse =
   'I could not read that attachment. Please type your question instead'
 
+// A message forwarded or shared into the DM with no comment typed. There is
+// content, but no question in it, and the person is waiting on a reply.
+const noQuestionInShareResponse =
+  'I can see what you shared, but not a question. Please type your question and I will look it up'
+
 // The attachment was no use, but a question was typed alongside it, so there
 // is something to answer. Short, because the answer is on its way.
 const attachmentFallbackResponse =
@@ -191,6 +196,19 @@ app.event('message', async ({ event, client }) => {
           .catch(console.error)
         return
       }
+    } else if (!hasQuestionText(event)) {
+      // Nothing typed, no file: a message forwarded or shared into the DM with
+      // no comment, whose content sits in event.attachments. Deliberately not
+      // answered as though it were the question, because the sender never
+      // framed it as one, but they are waiting on a reply, so ask for one.
+      await client.chat
+        .postMessage({
+          channel: event.channel,
+          text: noQuestionInShareResponse,
+          thread_ts: event.ts
+        })
+        .catch(console.error)
+      return
     } else {
       client.chat
         .postMessage({

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -74,11 +74,20 @@ app.event('message', async ({ event, client }) => {
     let processingError = false
     let questionInput = event.text
 
-    client.reactions.add({
-      channel: event.channel,
-      name: 'thumbsup',
-      timestamp: event.ts
-    })
+    // Deliberately not awaited, here and for the interim acknowledgements
+    // below: neither gates the answer, so the answer should not wait on them
+    // and the latency stays as it was. What they do need is a catch. The
+    // WebClient rejects with a WebAPIPlatformError on ok: false, and
+    // already_reacted on a Slack redelivery, msg_too_long, or a 429 after
+    // retries is nothing the handler's try/catch or app.error can see: an
+    // unhandled rejection ends the process and every request in flight on it.
+    client.reactions
+      .add({
+        channel: event.channel,
+        name: 'thumbsup',
+        timestamp: event.ts
+      })
+      .catch(console.error)
 
     try {
       const clientReq = await client.users.info({
@@ -100,11 +109,13 @@ app.event('message', async ({ event, client }) => {
         const transcribedQuestion = await transcribe(event.files[0], openai)
         if (transcribedQuestion) {
           questionInput = transcribedQuestion
-          client.chat.postMessage({
-            channel: event.channel,
-            text: `Give me a moment whilst I check for you. You asked: "${transcribedQuestion}"`,
-            thread_ts: event.ts
-          })
+          client.chat
+            .postMessage({
+              channel: event.channel,
+              text: `Give me a moment whilst I check for you. You asked: "${transcribedQuestion}"`,
+              thread_ts: event.ts
+            })
+            .catch(console.error)
         } else if (!hasQuestionText(event)) {
           // The audio yielded no words and there is nothing typed to fall back
           // on, so there is no question to look up. Say so, rather than asking
@@ -127,10 +138,12 @@ app.event('message', async ({ event, client }) => {
         processingError = !hasQuestionText(event)
       }
     } else {
-      client.chat.postMessage({
-        channel: event.channel,
-        text: `Thanks for your question. Let me check available information on that for you.`
-      })
+      client.chat
+        .postMessage({
+          channel: event.channel,
+          text: `Thanks for your question. Let me check available information on that for you.`
+        })
+        .catch(console.error)
     }
 
     if (!processingError) {

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -92,14 +92,12 @@ app.event('message', async ({ event, client }) => {
 
     if (hasFileAttachment(event)) {
       try {
-        // Whisper's text format returns a plain string, newline terminated,
-        // and only whitespace for audio with no speech in it. Trim once and
-        // decide on the trimmed value: a whitespace-only string is truthy, so
-        // branching on the raw one both skipped the message below and
-        // overwrote a question the user had typed alongside the file.
-        const transcribedQuestion = (
-          await transcribe(event.files[0], openai)
-        ).trim()
+        // transcribe trims what it returns, so the empty string is exactly
+        // "no words were heard" and is what this branches on. Whisper's text
+        // format gives only whitespace for audio with no speech in it, and a
+        // whitespace-only string is truthy, which is why the normalisation
+        // matters and why it lives in one place.
+        const transcribedQuestion = await transcribe(event.files[0], openai)
         if (transcribedQuestion) {
           questionInput = transcribedQuestion
           client.chat.postMessage({

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -73,6 +73,9 @@ app.event('message', async ({ event, client }) => {
     let answer = null
     let processingError = false
     let questionInput = event.text
+    // Set when the audio carried no words and nothing was typed alongside it.
+    // Decided inside the guarded block below and acted on after it.
+    let audioHadNoWords = false
 
     // Deliberately not awaited, here and for the interim acknowledgements
     // below: neither gates the answer, so the answer should not wait on them
@@ -118,15 +121,11 @@ app.event('message', async ({ event, client }) => {
             .catch(console.error)
         } else if (!hasQuestionText(event)) {
           // The audio yielded no words and there is nothing typed to fall back
-          // on, so there is no question to look up. Say so, rather than asking
-          // getAnswer for an answer to nothing and reporting its failure as
-          // ours.
-          await client.chat.postMessage({
-            channel: event.channel,
-            text: unintelligibleAudioResponse,
-            thread_ts: event.ts
-          })
-          return
+          // on, so there is no question to look up. Only the decision is made
+          // here: saying so is done outside this block, because a Slack
+          // failure posting it is not a transcription failure and must not be
+          // answered with the generic error the catch below would reach for.
+          audioHadNoWords = true
         }
       } catch (err) {
         console.error('transcription error', err)
@@ -136,6 +135,20 @@ app.event('message', async ({ event, client }) => {
         // answerable question. With nothing typed there is no fallback, and
         // the generic failure below stands.
         processingError = !hasQuestionText(event)
+      }
+
+      if (audioHadNoWords) {
+        // Nothing went wrong on our side, so this is the whole reply and the
+        // catch is here rather than around it: if Slack will not take the
+        // notice, there is nothing better to tell the user instead.
+        await client.chat
+          .postMessage({
+            channel: event.channel,
+            text: unintelligibleAudioResponse,
+            thread_ts: event.ts
+          })
+          .catch(console.error)
+        return
       }
     } else {
       client.chat

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -5,9 +5,9 @@ import { getAnswer, initialize } from './getAnswer.js'
 import { transcribe } from './utils.js'
 import {
   carriesQuestion,
-  hasFileAttachment,
   hasQuestionText,
-  isPlainUserMessage
+  isPlainUserMessage,
+  isTranscribableFile
 } from './messageEvents.js'
 import summarize from './summarize.js'
 
@@ -49,6 +49,17 @@ const errorResponse =
 const unintelligibleAudioResponse =
   'I could not make out any words in that recording. Please try again, or type your question instead'
 
+// Also not our failure: a document, an image, a video, or a file Slack will
+// not let us download. Telling someone to try again, as the generic failure
+// does, sends them round a loop that cannot help.
+const unreadableAttachmentResponse =
+  'I could not read that attachment. Please type your question instead'
+
+// The attachment was no use, but a question was typed alongside it, so there
+// is something to answer. Short, because the answer is on its way.
+const attachmentFallbackResponse =
+  'I could not get anything from that attachment, so I will answer the question you typed.'
+
 app.event('message', async ({ event, client }) => {
   console.log('message event', event)
 
@@ -76,6 +87,9 @@ app.event('message', async ({ event, client }) => {
     // Set when the audio carried no words and nothing was typed alongside it.
     // Decided inside the guarded block below and acted on after it.
     let audioHadNoWords = false
+    // Set when the attachment was no use but a question was typed alongside
+    // it, so the answer can say the file was not read.
+    let fellBackToTypedText = false
 
     // Deliberately not awaited, here and for the interim acknowledgements
     // below: neither gates the answer, so the answer should not wait on them
@@ -102,14 +116,19 @@ app.event('message', async ({ event, client }) => {
       console.error('error', error)
     }
 
-    if (hasFileAttachment(event)) {
+    const [attachedFile] = event.files ?? []
+    const fileToTranscribe = isTranscribableFile(attachedFile)
+      ? attachedFile
+      : null
+
+    if (fileToTranscribe) {
       try {
         // transcribe trims what it returns, so the empty string is exactly
         // "no words were heard" and is what this branches on. Whisper's text
         // format gives only whitespace for audio with no speech in it, and a
         // whitespace-only string is truthy, which is why the normalisation
         // matters and why it lives in one place.
-        const transcribedQuestion = await transcribe(event.files[0], openai)
+        const transcribedQuestion = await transcribe(fileToTranscribe, openai)
         if (transcribedQuestion) {
           questionInput = transcribedQuestion
           client.chat
@@ -126,15 +145,18 @@ app.event('message', async ({ event, client }) => {
           // failure posting it is not a transcription failure and must not be
           // answered with the generic error the catch below would reach for.
           audioHadNoWords = true
+        } else {
+          // No words, but a question was typed alongside the recording, so
+          // that is what gets answered.
+          fellBackToTypedText = true
         }
       } catch (err) {
         console.error('transcription error', err)
-        // The file failed, not the question. Whisper rejects a body that is
-        // not audio, which is what a PDF or screenshot upload gives it, so
-        // fall back to anything typed alongside rather than losing an
-        // answerable question. With nothing typed there is no fallback, and
-        // the generic failure below stands.
+        // The file failed, not the question, so fall back to anything typed
+        // alongside rather than losing an answerable question. With nothing
+        // typed there is no fallback, and the generic failure below stands.
         processingError = !hasQuestionText(event)
+        fellBackToTypedText = !processingError
       }
 
       if (audioHadNoWords) {
@@ -150,11 +172,43 @@ app.event('message', async ({ event, client }) => {
           .catch(console.error)
         return
       }
+    } else if (attachedFile) {
+      // A file we will not transcribe: a document, an image, a video, or one
+      // Slack served us no download URL for. Nothing is sent to OpenAI.
+      if (hasQuestionText(event)) {
+        fellBackToTypedText = true
+      } else {
+        // Nothing typed and nothing we can read, so there is no question to
+        // look up. This is the user's situation to fix, not an internal
+        // failure, and the generic error told them to try again when retrying
+        // cannot help.
+        await client.chat
+          .postMessage({
+            channel: event.channel,
+            text: unreadableAttachmentResponse,
+            thread_ts: event.ts
+          })
+          .catch(console.error)
+        return
+      }
     } else {
       client.chat
         .postMessage({
           channel: event.channel,
           text: `Thanks for your question. Let me check available information on that for you.`
+        })
+        .catch(console.error)
+    }
+
+    if (fellBackToTypedText) {
+      // The attachment was no use, so say so and answer what was typed. Left
+      // unsaid, the person waited the whole embeddings and completion round
+      // trip on a bare thumbsup and was never told the file was ignored.
+      client.chat
+        .postMessage({
+          channel: event.channel,
+          text: attachmentFallbackResponse,
+          thread_ts: event.ts
         })
         .catch(console.error)
     }

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -121,10 +121,14 @@ app.event('message', async ({ event, client }) => {
       console.error('error', error)
     }
 
-    const [attachedFile] = event.files ?? []
-    const fileToTranscribe = isTranscribableFile(attachedFile)
-      ? attachedFile
-      : null
+    const attachedFiles = event.files ?? []
+    // The first file we can transcribe, not the first file: a document
+    // uploaded alongside a voice note told the person their attachment could
+    // not be read while the recording was silently ignored. The first file is
+    // still what the unreadable-attachment reply below is about, since by then
+    // there is nothing transcribable among them.
+    const fileToTranscribe = attachedFiles.find(isTranscribableFile) ?? null
+    const [attachedFile] = attachedFiles
 
     if (fileToTranscribe) {
       try {

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -92,12 +92,19 @@ app.event('message', async ({ event, client }) => {
 
     if (hasFileAttachment(event)) {
       try {
-        const transcribedResponse = await transcribe(event.files[0], openai)
-        if (transcribedResponse) {
-          questionInput = transcribedResponse
+        // Whisper's text format returns a plain string, newline terminated,
+        // and only whitespace for audio with no speech in it. Trim once and
+        // decide on the trimmed value: a whitespace-only string is truthy, so
+        // branching on the raw one both skipped the message below and
+        // overwrote a question the user had typed alongside the file.
+        const transcribedQuestion = (
+          await transcribe(event.files[0], openai)
+        ).trim()
+        if (transcribedQuestion) {
+          questionInput = transcribedQuestion
           client.chat.postMessage({
             channel: event.channel,
-            text: `Give me a moment whilst I check for you. You asked: "${transcribedResponse.trim()}"`,
+            text: `Give me a moment whilst I check for you. You asked: "${transcribedQuestion}"`,
             thread_ts: event.ts
           })
         } else if (!hasQuestionText(event)) {

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -121,7 +121,12 @@ app.event('message', async ({ event, client }) => {
         }
       } catch (err) {
         console.error('transcription error', err)
-        processingError = true
+        // The file failed, not the question. Whisper rejects a body that is
+        // not audio, which is what a PDF or screenshot upload gives it, so
+        // fall back to anything typed alongside rather than losing an
+        // answerable question. With nothing typed there is no fallback, and
+        // the generic failure below stands.
+        processingError = !hasQuestionText(event)
       }
     } else {
       client.chat.postMessage({

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -97,8 +97,8 @@ app.event('message', async ({ event, client }) => {
     let fellBackToTypedText = false
 
     // Deliberately not awaited, here and for the interim acknowledgements
-    // below: neither gates the answer, so the answer should not wait on them
-    // and the latency stays as it was. What they do need is a catch. The
+    // below: none of them gates the answer, so the answer should not wait on
+    // them and the latency stays as it was. What they do need is a catch. The
     // WebClient rejects with a WebAPIPlatformError on ok: false, and
     // already_reacted on a Slack redelivery, msg_too_long, or a 429 after
     // retries is nothing the handler's try/catch or app.error can see: an

--- a/packages/slack-bot/src/bot.js
+++ b/packages/slack-bot/src/bot.js
@@ -3,6 +3,11 @@ import bolt from '@slack/bolt'
 import OpenAI from 'openai'
 import { getAnswer, initialize } from './getAnswer.js'
 import { transcribe } from './utils.js'
+import {
+  carriesQuestion,
+  hasFileAttachment,
+  isPlainUserMessage
+} from './messageEvents.js'
 import summarize from './summarize.js'
 
 const { App, ExpressReceiver } = bolt
@@ -41,7 +46,19 @@ const errorResponse =
 app.event('message', async ({ event, client }) => {
   console.log('message event', event)
 
-  if (event.subtype && event.subtype === 'bot_message') {
+  // Both guards sit ahead of the reaction and the acknowledgement below, so an
+  // event we should not answer produces no visible trace at all.
+  //
+  // A link unfurl on the bot's own answer comes back as a message event, and
+  // answering it posts a question nobody asked, reacts to the bot's own
+  // message, and can unfurl again in turn.
+  if (!isPlainUserMessage(event)) {
+    return
+  }
+
+  // Nothing to answer, and nothing a person is waiting on either: an event we
+  // should not have been sent rather than a user visible situation.
+  if (!carriesQuestion(event)) {
     return
   }
 
@@ -67,7 +84,7 @@ app.event('message', async ({ event, client }) => {
       console.error('error', error)
     }
 
-    if (event.files && event.files[0]) {
+    if (hasFileAttachment(event)) {
       try {
         const transcribedResponse = await transcribe(event.files[0], openai)
         if (transcribedResponse) {

--- a/packages/slack-bot/src/getAnswer.js
+++ b/packages/slack-bot/src/getAnswer.js
@@ -142,12 +142,19 @@ async function createContext({
 async function getAnswer({
   dataSet: customDataSet,
   model = 'gpt-4.1',
-  question = 'What is NearForm?',
+  question,
   maxLength = parsePositiveTokenCount(process.env.MAX_CONTEXT_TOKENS, 4000),
   embeddingModel = defaultEmbeddingModel,
   locale = 'en-IE',
   openai
 }) {
+  // No default: a question this function invented would be answered as
+  // confidently as one a person asked, which is how a spurious Slack event
+  // turned into a plausible looking answer rather than an obvious failure.
+  if (typeof question !== 'string' || question.trim().length === 0) {
+    throw new Error('getAnswer requires a question')
+  }
+
   await initialize()
   const dataSet = customDataSet ?? defaultDataSet
   if (!dataSet) {

--- a/packages/slack-bot/src/messageEvents.js
+++ b/packages/slack-bot/src/messageEvents.js
@@ -97,14 +97,51 @@ export function hasQuestionText(event) {
 }
 
 /**
- * Whether the event carries a file, which transcription may turn into a
- * question.
+ * Whether the event carries a file at all, transcribable or not.
+ *
+ * Deliberately not narrowed to the files we can transcribe: a file we cannot
+ * read is still something a person sent and is waiting on, so it has to reach
+ * the handler and get a reaction and a reply. What we do with the file is
+ * `isTranscribableFile`'s decision.
  *
  * @param {Object} event a Slack `message` event
  * @returns {boolean}
  */
 export function hasFileAttachment(event) {
   return Boolean(event.files && event.files[0])
+}
+
+/**
+ * Whether a file is one we should send to the transcription API.
+ *
+ * Both halves are required. Without the audio check any attachment was
+ * downloaded and posted to OpenAI's audio endpoint, so a PDF or a screenshot
+ * of potentially confidential client content was uploaded for nothing, and a
+ * screen recording, whose audio track Whisper transcribes happily, had its
+ * soundtrack answered instead of the question its owner typed alongside it.
+ * Without the URL check `new URL(undefined)` threw a `TypeError`: Slack
+ * Connect and restricted files arrive as a stub carrying `file_access`, and
+ * `hidden_by_limit` and external-mode files have no download URL either, all
+ * of which surfaced to the user as a generic internal failure.
+ *
+ * @param {Object} [file] a Slack file from `event.files`
+ * @returns {boolean}
+ */
+export function isTranscribableFile(file) {
+  if (!file) {
+    return false
+  }
+
+  const isAudio =
+    (typeof file.mimetype === 'string' && file.mimetype.startsWith('audio/')) ||
+    // What Slack marks its own voice notes with.
+    file.subtype === 'slack_audio'
+
+  return (
+    isAudio &&
+    typeof file.url_private_download === 'string' &&
+    file.url_private_download.length > 0
+  )
 }
 
 /**

--- a/packages/slack-bot/src/messageEvents.js
+++ b/packages/slack-bot/src/messageEvents.js
@@ -4,20 +4,70 @@
  */
 
 /**
+ * Subtypes of the `message` event that are never a person asking something.
+ *
+ * A deny list rather than an allow list, deliberately. We are not confident we
+ * know every subtype string Slack may send, and an unrecognised one is far
+ * better answered, which is what the bot did before this guard existed, than
+ * silently dropped. Getting an answer nobody expected is visible; getting no
+ * answer at all looks like the bot is broken.
+ *
+ * The entries fall into two groups. `bot_message`, `message_changed`,
+ * `message_deleted`, `message_replied`, `tombstone` and `ekm_access_denied`
+ * are the bot's or the workspace's own doing, not a message anyone typed: a
+ * link unfurl on the bot's own answer is the `message_changed` one, and it is
+ * what issue #983 was about. The rest are the channel membership and channel
+ * metadata notices, whose text reads like "so-and-so joined the channel" or
+ * "set the channel topic", which the model would happily answer as a question.
+ *
+ * Subtypes that are still a person speaking are absent on purpose, so they are
+ * answered: `file_share` (an upload, including a voice note, with the file in
+ * `event.files`), `thread_broadcast` and `me_message` all keep their text at
+ * `event.text`.
+ */
+const nonUserMessageSubtypes = new Set([
+  'bot_message',
+  'message_changed',
+  'message_deleted',
+  'message_replied',
+  'tombstone',
+  'ekm_access_denied',
+  'channel_join',
+  'channel_leave',
+  'channel_topic',
+  'channel_purpose',
+  'channel_name',
+  'channel_archive',
+  'channel_unarchive',
+  'group_join',
+  'group_leave',
+  'group_topic',
+  'group_purpose',
+  'group_name',
+  'group_archive',
+  'group_unarchive'
+])
+
+/**
  * Whether a `message` event is a plain message a person sent.
  *
- * Slack delivers far more than typed messages on this event. Edits, deletions,
- * joins and channel changes arrive as subtypes, and a link unfurl on the bot's
- * own answer arrives as a `message_changed` subtype carrying the bot's
- * `bot_id` and `hidden: true`. Only a plain user message keeps its text at
- * `event.text`, so treating any of the others as a question asks the model
- * something nobody asked.
+ * Slack delivers far more than typed messages on this event. A link unfurl on
+ * the bot's own answer arrives as a `message_changed` subtype with
+ * `hidden: true`, and it keeps its text at `event.message.text`, alongside the
+ * bot's own `bot_id`, so treating it as a question asks the model something
+ * nobody asked. A `bot_id` or `hidden` at the top level is rejected whatever
+ * the subtype, so that unfurl fails the deny list and the `hidden` check both.
  *
  * @param {Object} [event] a Slack `message` event
  * @returns {boolean}
  */
 export function isPlainUserMessage(event) {
-  return Boolean(event) && !event.subtype && !event.bot_id && !event.hidden
+  return (
+    Boolean(event) &&
+    !nonUserMessageSubtypes.has(event.subtype) &&
+    !event.bot_id &&
+    !event.hidden
+  )
 }
 
 /**

--- a/packages/slack-bot/src/messageEvents.js
+++ b/packages/slack-bot/src/messageEvents.js
@@ -19,10 +19,11 @@
  * what issue #983 was about. The rest are notices Slack writes on someone's
  * behalf, whose text reads like "pinned a message to this conversation" or
  * "so-and-so joined the channel", which the model would happily answer as a
- * question. `pinned_item` through `app_conversation_join` are the ones that
- * can arrive on the `message.im` subscription the bot has today, and a pin on
- * one of the bot's own answers is the likeliest of them. The `channel_*` and
- * `group_*` entries cannot arrive on that subscription, and are kept because
+ * question. `pinned_item` through `app_conversation_join` are the notices we
+ * expect on `message.im`, which is the only event the manifest subscribes to,
+ * and a pin on one of the bot's own answers is the likeliest of them. The
+ * `channel_*` and `group_*` entries are notices about channel and group
+ * conversations, which that subscription does not cover; they are kept because
  * they cost nothing and would matter the moment a channel subscription is
  * added.
  *

--- a/packages/slack-bot/src/messageEvents.js
+++ b/packages/slack-bot/src/messageEvents.js
@@ -16,9 +16,15 @@
  * `message_deleted`, `message_replied`, `tombstone` and `ekm_access_denied`
  * are the bot's or the workspace's own doing, not a message anyone typed: a
  * link unfurl on the bot's own answer is the `message_changed` one, and it is
- * what issue #983 was about. The rest are the channel membership and channel
- * metadata notices, whose text reads like "so-and-so joined the channel" or
- * "set the channel topic", which the model would happily answer as a question.
+ * what issue #983 was about. The rest are notices Slack writes on someone's
+ * behalf, whose text reads like "pinned a message to this conversation" or
+ * "so-and-so joined the channel", which the model would happily answer as a
+ * question. `pinned_item` through `app_conversation_join` are the ones that
+ * can arrive on the `message.im` subscription the bot has today, and a pin on
+ * one of the bot's own answers is the likeliest of them. The `channel_*` and
+ * `group_*` entries cannot arrive on that subscription, and are kept because
+ * they cost nothing and would matter the moment a channel subscription is
+ * added.
  *
  * Subtypes that are still a person speaking are absent on purpose, so they are
  * answered: `file_share` (an upload, including a voice note, with the file in
@@ -32,6 +38,14 @@ const nonUserMessageSubtypes = new Set([
   'message_replied',
   'tombstone',
   'ekm_access_denied',
+  'pinned_item',
+  'unpinned_item',
+  'reminder_add',
+  'huddle_thread',
+  'bot_add',
+  'bot_remove',
+  'sh_room_created',
+  'app_conversation_join',
   'channel_join',
   'channel_leave',
   'channel_topic',

--- a/packages/slack-bot/src/messageEvents.js
+++ b/packages/slack-bot/src/messageEvents.js
@@ -1,0 +1,54 @@
+/**
+ * Decisions about which Slack `message` events the bot should answer, kept
+ * apart from the handler so they can be tested without constructing a Bolt app.
+ */
+
+/**
+ * Whether a `message` event is a plain message a person sent.
+ *
+ * Slack delivers far more than typed messages on this event. Edits, deletions,
+ * joins and channel changes arrive as subtypes, and a link unfurl on the bot's
+ * own answer arrives as a `message_changed` subtype carrying the bot's
+ * `bot_id` and `hidden: true`. Only a plain user message keeps its text at
+ * `event.text`, so treating any of the others as a question asks the model
+ * something nobody asked.
+ *
+ * @param {Object} [event] a Slack `message` event
+ * @returns {boolean}
+ */
+export function isPlainUserMessage(event) {
+  return Boolean(event) && !event.subtype && !event.bot_id && !event.hidden
+}
+
+/**
+ * Whether the event carries text a person typed. Deliberately reads only
+ * `event.text`: the nested `event.message.text` belongs to an edited or
+ * unfurled message, which `isPlainUserMessage` rejects.
+ *
+ * @param {Object} event a Slack `message` event
+ * @returns {boolean}
+ */
+export function hasQuestionText(event) {
+  return typeof event.text === 'string' && event.text.trim().length > 0
+}
+
+/**
+ * Whether the event carries a file, which transcription may turn into a
+ * question.
+ *
+ * @param {Object} event a Slack `message` event
+ * @returns {boolean}
+ */
+export function hasFileAttachment(event) {
+  return Boolean(event.files && event.files[0])
+}
+
+/**
+ * Whether there is anything to answer: typed text, or a file to transcribe.
+ *
+ * @param {Object} event a Slack `message` event
+ * @returns {boolean}
+ */
+export function carriesQuestion(event) {
+  return hasQuestionText(event) || hasFileAttachment(event)
+}

--- a/packages/slack-bot/src/messageEvents.js
+++ b/packages/slack-bot/src/messageEvents.js
@@ -145,11 +145,35 @@ export function isTranscribableFile(file) {
 }
 
 /**
- * Whether there is anything to answer: typed text, or a file to transcribe.
+ * Whether the event carries message attachments, which is where the content of
+ * a message forwarded or shared into the DM arrives.
+ *
+ * Slack's `attachments` are not `files`: Share or Forward with no comment
+ * typed sends an empty `text`, no `files`, and the shared message in
+ * `attachments`.
+ *
+ * @param {Object} event a Slack `message` event
+ * @returns {boolean}
+ */
+export function hasAttachments(event) {
+  return Boolean(event.attachments && event.attachments.length > 0)
+}
+
+/**
+ * Whether the event is one a person is waiting on a reply to: typed text, a
+ * file, or a forwarded message.
+ *
+ * Not the same question as whether there is something answerable. A forwarded
+ * message with no comment has no question in it, and the handler asks for one
+ * rather than answering content the sender never framed as a question, but
+ * dropping it here left the person staring at a DM the bot had not even
+ * reacted to.
  *
  * @param {Object} event a Slack `message` event
  * @returns {boolean}
  */
 export function carriesQuestion(event) {
-  return hasQuestionText(event) || hasFileAttachment(event)
+  return (
+    hasQuestionText(event) || hasFileAttachment(event) || hasAttachments(event)
+  )
 }

--- a/packages/slack-bot/src/utils.js
+++ b/packages/slack-bot/src/utils.js
@@ -3,6 +3,8 @@ import f from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import https from 'node:https'
+import stream from 'node:stream'
+import { randomUUID } from 'node:crypto'
 import { Storage } from '@google-cloud/storage'
 import { findRootSync } from '@manypkg/find-root'
 import { csv2json } from 'json-2-csv'
@@ -48,21 +50,47 @@ export function distancesFromEmbeddings({ queryEmbedding, embeddings }) {
 }
 
 /**
- * How long the audio download may take before it is abandoned. Slack accepting
- * the connection and then sending nothing used to leave the message handler
- * waiting on a promise that could never settle.
+ * How long the audio download may go without activity before it is abandoned.
+ * An inactivity deadline rather than a total budget: a slow but steady
+ * download is left to finish. Slack accepting the connection and then sending
+ * nothing used to leave the message handler waiting on a promise that could
+ * never settle, and that is the case this closes.
  */
 const audioDownloadTimeoutMs = 30_000
 
 /**
+ * Remove a scratch file, tolerating it already being gone.
+ *
+ * The service runs with --min-instances=1 on a 512MB Cloud Run instance, where
+ * the filesystem is memory and an instance lives indefinitely: one file left
+ * behind per upload grows until the instance is OOM-killed. Failing to remove
+ * one is worth knowing about, but it must never replace the result, or the
+ * failure, the caller was about to report.
+ *
+ * @param {string} filePath
+ * @returns {Promise<void>}
+ */
+async function removeScratchFile(filePath) {
+  await fs.unlink(filePath).catch(error => {
+    if (error.code !== 'ENOENT') {
+      console.error('could not remove the downloaded audio', error)
+    }
+  })
+}
+
+/**
  * Download the audio a Slack file points at to a local scratch file.
  *
- * Every failure has to reject: the request failing to connect, the response
- * breaking part way through, the file failing to write, the response stalling,
- * and a non-2xx answer such as the error body an expired or forbidden download
- * URL serves. Unlistened-for stream errors were uncaught exceptions, which
- * functions-framework turns into a process exit that takes every in-flight
- * request with it.
+ * Every failure has to reject, and it has to leave nothing behind: the request
+ * failing to connect, the response breaking part way through, the file failing
+ * to write, the response stalling, and a non-2xx answer such as the error body
+ * an expired or forbidden download URL serves. Unlistened-for stream errors
+ * were uncaught exceptions, which functions-framework turns into a process
+ * exit that takes every in-flight request with it. A mid-stream failure then
+ * left a partial file and an open write handle, because piping does not tear
+ * the destination down when the source fails, and `transcribe` cannot clean up
+ * after that one: this throws before it ever returns a path, so the caller's
+ * finally is never reached.
  *
  * @param {string} url the file's `url_private_download`
  * @param {string} id the Slack file id, used to name the scratch file
@@ -72,55 +100,73 @@ export async function downloadAudio(url, id) {
   const slackUrl = new URL(url)
   // The working directory of a Cloud Run instance is an in-memory filesystem
   // charged against the instance memory limit, so a scratch file belongs in
-  // the temporary directory instead.
-  const destination = path.join(os.tmpdir(), `${id}.mp4`)
+  // the temporary directory instead. The random suffix keeps two runs for the
+  // same Slack file apart: Slack redelivers an event it has not seen a 200
+  // for, and on one shared destination the two downloads wrote over each other
+  // and the first to finish removed the file the other was still reading.
+  const destination = path.join(os.tmpdir(), `${id}-${randomUUID()}.mp4`)
 
-  return new Promise((resolve, reject) => {
-    const request = https.get(
-      {
-        hostname: slackUrl.hostname,
-        path: slackUrl.pathname,
-        headers: {
-          authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`
+  try {
+    await new Promise((resolve, reject) => {
+      const request = https.get(
+        {
+          hostname: slackUrl.hostname,
+          port: slackUrl.port || undefined,
+          // url_private_download is a signed URL, so the query string is part
+          // of the request and not decoration.
+          path: `${slackUrl.pathname}${slackUrl.search}`,
+          headers: {
+            authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`
+          },
+          timeout: audioDownloadTimeoutMs
         },
-        timeout: audioDownloadTimeoutMs
-      },
-      response => {
-        const { statusCode } = response
-        if (!statusCode || statusCode < 200 || statusCode >= 300) {
-          // Drain and abandon it: writing an error body to disk and handing it
-          // to Whisper as though it were audio helps nobody.
-          response.resume()
-          request.destroy()
-          reject(
-            new Error(
-              `downloading the audio failed with HTTP status ${statusCode}`
+        response => {
+          const { statusCode } = response
+          if (!statusCode || statusCode < 200 || statusCode >= 300) {
+            // Drain and abandon it: writing an error body to disk and handing
+            // it to Whisper as though it were audio helps nobody.
+            response.resume()
+            request.destroy()
+            reject(
+              new Error(
+                `downloading the audio failed with HTTP status ${statusCode}`
+              )
             )
-          )
-          return
+            return
+          }
+
+          // pipeline rather than pipe: it reports either side's failure through
+          // the one callback and destroys both streams on the way, which is
+          // what closes the write handle on a download that breaks part way
+          // through.
+          stream.pipeline(response, f.createWriteStream(destination), error => {
+            if (error) {
+              reject(error)
+              return
+            }
+            resolve()
+          })
         }
-
-        const audioFile = f.createWriteStream(destination)
-        response.on('error', reject)
-        audioFile.on('error', reject)
-        audioFile.on('finish', () => {
-          resolve(destination)
-        })
-        response.pipe(audioFile)
-      }
-    )
-
-    request.on('error', reject)
-    request.on('timeout', () => {
-      // A timeout does not close the socket by itself, and destroying with an
-      // error is what turns it into a rejection through the listener above.
-      request.destroy(
-        new Error(
-          `downloading the audio timed out after ${audioDownloadTimeoutMs}ms`
-        )
       )
+
+      request.on('error', reject)
+      request.on('timeout', () => {
+        // A timeout does not close the socket by itself, and destroying with an
+        // error is what turns it into a rejection through the listener above.
+        request.destroy(
+          new Error(
+            `downloading the audio timed out after ${audioDownloadTimeoutMs}ms`
+          )
+        )
+      })
     })
-  })
+  } catch (error) {
+    // Whatever went wrong, the partial file must not outlive the attempt.
+    await removeScratchFile(destination)
+    throw error
+  }
+
+  return destination
 }
 
 /**
@@ -179,17 +225,8 @@ export async function transcribe(file, openai) {
   } finally {
     audioStream.destroy()
     // The caller only ever sees the transcription, so cleaning up has to
-    // happen here. The service runs with --min-instances=1 on a 512MB Cloud
-    // Run instance, where the filesystem is memory and an instance lives
-    // indefinitely: one file left behind per upload grows until the instance
-    // is OOM-killed. A rejected transcription leaks just as readily as a
+    // happen here, and a rejected transcription leaks just as readily as a
     // successful one, hence the finally.
-    await fs.unlink(downloadedPath).catch(error => {
-      // Already gone is the outcome we wanted. Anything else is worth knowing
-      // about but must not replace the transcription result or its failure.
-      if (error.code !== 'ENOENT') {
-        console.error('could not remove the downloaded audio', error)
-      }
-    })
+    await removeScratchFile(downloadedPath)
   }
 }

--- a/packages/slack-bot/src/utils.js
+++ b/packages/slack-bot/src/utils.js
@@ -68,17 +68,41 @@ export async function downloadAudio(url, id) {
 }
 
 /**
+ * The text of a transcription, whatever shape the SDK returned it in.
  *
- * @param {*} file
+ * With `response_format: 'text'` the SDK resolves to the transcription as a
+ * plain string, so reading `.text` off it gave `undefined`. Other formats
+ * resolve to an object carrying `text`. Both are handled here rather than in
+ * the caller, so changing the format cannot quietly return nothing again, and
+ * anything else gives the empty string a silent recording would.
+ *
+ * @param {string | { text?: string } | undefined} transcription
+ * @returns {string}
+ */
+export function transcriptionText(transcription) {
+  if (typeof transcription === 'string') {
+    return transcription
+  }
+  if (transcription && typeof transcription.text === 'string') {
+    return transcription.text
+  }
+  return ''
+}
+
+/**
+ * Transcribe an audio file a person sent, such as a voice note.
+ *
+ * @param {*} file a Slack file from `event.files`
  * @param {import('openai').OpenAI} openai
- * @returns
+ * @returns {Promise<string>} the transcription, or the empty string if the
+ *   audio yielded no words
  */
 export async function transcribe(file, openai) {
   const p = await downloadAudio(file.url_private_download, file.id)
-  const transcribe = await openai.audio.transcriptions.create({
+  const transcription = await openai.audio.transcriptions.create({
     file: f.createReadStream(p),
     model: 'whisper-1',
     response_format: 'text'
   })
-  return transcribe.text
+  return transcriptionText(transcription)
 }

--- a/packages/slack-bot/src/utils.js
+++ b/packages/slack-bot/src/utils.js
@@ -132,15 +132,21 @@ export async function downloadAudio(url, id) {
  * the caller, so changing the format cannot quietly return nothing again, and
  * anything else gives the empty string a silent recording would.
  *
+ * The result is trimmed, so "no words were heard" is exactly the empty string
+ * and callers can branch on it directly. Whisper's text format newline
+ * terminates what it returns and gives only whitespace for audio with no
+ * speech in it, and a whitespace-only string is truthy: trimming here rather
+ * than in each caller is what makes the returns below true.
+ *
  * @param {string | { text?: string } | undefined} transcription
- * @returns {string}
+ * @returns {string} the words heard, or the empty string if there were none
  */
 export function transcriptionText(transcription) {
   if (typeof transcription === 'string') {
-    return transcription
+    return transcription.trim()
   }
   if (transcription && typeof transcription.text === 'string') {
-    return transcription.text
+    return transcription.text.trim()
   }
   return ''
 }
@@ -150,8 +156,8 @@ export function transcriptionText(transcription) {
  *
  * @param {*} file a Slack file from `event.files`
  * @param {import('openai').OpenAI} openai
- * @returns {Promise<string>} the transcription, or the empty string if the
- *   audio yielded no words
+ * @returns {Promise<string>} the transcription, trimmed, or the empty string
+ *   if the audio yielded no words
  */
 export async function transcribe(file, openai) {
   const downloadedPath = await downloadAudio(file.url_private_download, file.id)

--- a/packages/slack-bot/src/utils.js
+++ b/packages/slack-bot/src/utils.js
@@ -154,11 +154,36 @@ export function transcriptionText(transcription) {
  *   audio yielded no words
  */
 export async function transcribe(file, openai) {
-  const p = await downloadAudio(file.url_private_download, file.id)
-  const transcription = await openai.audio.transcriptions.create({
-    file: f.createReadStream(p),
-    model: 'whisper-1',
-    response_format: 'text'
+  const downloadedPath = await downloadAudio(file.url_private_download, file.id)
+  const audioStream = f.createReadStream(downloadedPath)
+  // The SDK reads the stream to upload it, but a rejection before it gets
+  // there leaves the stream open, and it would then fail on the file removed
+  // below with nothing listening for the error.
+  audioStream.on('error', error => {
+    console.error('could not read the downloaded audio', error)
   })
-  return transcriptionText(transcription)
+
+  try {
+    const transcription = await openai.audio.transcriptions.create({
+      file: audioStream,
+      model: 'whisper-1',
+      response_format: 'text'
+    })
+    return transcriptionText(transcription)
+  } finally {
+    audioStream.destroy()
+    // The caller only ever sees the transcription, so cleaning up has to
+    // happen here. The service runs with --min-instances=1 on a 512MB Cloud
+    // Run instance, where the filesystem is memory and an instance lives
+    // indefinitely: one file left behind per upload grows until the instance
+    // is OOM-killed. A rejected transcription leaks just as readily as a
+    // successful one, hence the finally.
+    await fs.unlink(downloadedPath).catch(error => {
+      // Already gone is the outcome we wanted. Anything else is worth knowing
+      // about but must not replace the transcription result or its failure.
+      if (error.code !== 'ENOENT') {
+        console.error('could not remove the downloaded audio', error)
+      }
+    })
+  }
 }

--- a/packages/slack-bot/src/utils.js
+++ b/packages/slack-bot/src/utils.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import f from 'node:fs'
 import path from 'node:path'
+import os from 'node:os'
 import https from 'node:https'
 import { Storage } from '@google-cloud/storage'
 import { findRootSync } from '@manypkg/find-root'
@@ -46,24 +47,79 @@ export function distancesFromEmbeddings({ queryEmbedding, embeddings }) {
   return distance
 }
 
+/**
+ * How long the audio download may take before it is abandoned. Slack accepting
+ * the connection and then sending nothing used to leave the message handler
+ * waiting on a promise that could never settle.
+ */
+const audioDownloadTimeoutMs = 30_000
+
+/**
+ * Download the audio a Slack file points at to a local scratch file.
+ *
+ * Every failure has to reject: the request failing to connect, the response
+ * breaking part way through, the file failing to write, the response stalling,
+ * and a non-2xx answer such as the error body an expired or forbidden download
+ * URL serves. Unlistened-for stream errors were uncaught exceptions, which
+ * functions-framework turns into a process exit that takes every in-flight
+ * request with it.
+ *
+ * @param {string} url the file's `url_private_download`
+ * @param {string} id the Slack file id, used to name the scratch file
+ * @returns {Promise<string>} the path the audio was written to
+ */
 export async function downloadAudio(url, id) {
-  return new Promise(resolve => {
-    const u = new URL(url)
-    const dest = `./${id}.mp4`
-    https.get(
+  const slackUrl = new URL(url)
+  // The working directory of a Cloud Run instance is an in-memory filesystem
+  // charged against the instance memory limit, so a scratch file belongs in
+  // the temporary directory instead.
+  const destination = path.join(os.tmpdir(), `${id}.mp4`)
+
+  return new Promise((resolve, reject) => {
+    const request = https.get(
       {
-        hostname: u.hostname,
-        path: u.pathname,
+        hostname: slackUrl.hostname,
+        path: slackUrl.pathname,
         headers: {
           authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`
-        }
+        },
+        timeout: audioDownloadTimeoutMs
       },
-      res => {
-        res.pipe(f.createWriteStream(dest)).on('finish', () => {
-          resolve(dest)
+      response => {
+        const { statusCode } = response
+        if (!statusCode || statusCode < 200 || statusCode >= 300) {
+          // Drain and abandon it: writing an error body to disk and handing it
+          // to Whisper as though it were audio helps nobody.
+          response.resume()
+          request.destroy()
+          reject(
+            new Error(
+              `downloading the audio failed with HTTP status ${statusCode}`
+            )
+          )
+          return
+        }
+
+        const audioFile = f.createWriteStream(destination)
+        response.on('error', reject)
+        audioFile.on('error', reject)
+        audioFile.on('finish', () => {
+          resolve(destination)
         })
+        response.pipe(audioFile)
       }
     )
+
+    request.on('error', reject)
+    request.on('timeout', () => {
+      // A timeout does not close the socket by itself, and destroying with an
+      // error is what turns it into a rejection through the listener above.
+      request.destroy(
+        new Error(
+          `downloading the audio timed out after ${audioDownloadTimeoutMs}ms`
+        )
+      )
+    })
   })
 }
 

--- a/packages/slack-bot/test/getAnswerQuestionRequired.test.js
+++ b/packages/slack-bot/test/getAnswerQuestionRequired.test.js
@@ -1,0 +1,88 @@
+import fs from 'node:fs'
+import { describe, test, mock } from 'node:test'
+import sinon from 'sinon'
+import * as utils from '../src/utils.js'
+import { createChatCompletionResponse } from './mocks/chatCompletion.js'
+
+const embeddingsCsvMock = [
+  ',text,n_tokens,embeddings',
+  '0,"Content page 1",3,"[1, 0, 0, 0]"'
+].join('\n')
+
+const queryEmbeddingResponse = { data: [{ embedding: [1, 0, 0, 0] }] }
+
+// getAnswer.js starts loading the embeddings when the module loads, so the
+// mocks are registered before it is imported. A module specifier can only be
+// mocked once per process, and every test file runs in its own process.
+mock.module('../src/utils.js', {
+  namedExports: {
+    ...utils,
+    download: (_, __, destination) => {
+      fs.writeFileSync(destination, embeddingsCsvMock)
+    }
+  }
+})
+
+mock.module('@google-cloud/pubsub', {
+  namedExports: {
+    PubSub: class PubSubMock {
+      subscription = () => ({ on: () => {} })
+    }
+  }
+})
+
+const { getAnswer } = await import('../src/getAnswer.js')
+
+function createOpenaiMock() {
+  return {
+    embeddings: {
+      create: sinon.spy(async () => queryEmbeddingResponse)
+    },
+    chat: {
+      completions: {
+        create: sinon.spy(async () => createChatCompletionResponse)
+      }
+    }
+  }
+}
+
+describe('getAnswer requires a question', () => {
+  // A spurious Slack event used to reach getAnswer with no question at all,
+  // and a default parameter answered it as though someone had asked.
+  const unusableQuestions = [
+    { name: 'omitted', value: undefined },
+    { name: 'null', value: null },
+    { name: 'empty', value: '' },
+    { name: 'whitespace only', value: '   \n\t ' },
+    { name: 'not a string', value: 42 }
+  ]
+
+  for (const { name, value } of unusableQuestions) {
+    test(`rejects a ${name} question without calling OpenAI`, async t => {
+      const openaiMock = createOpenaiMock()
+
+      await t.assert.rejects(
+        getAnswer({ openai: openaiMock, question: value }),
+        /getAnswer requires a question/
+      )
+
+      // The bug also burned an embedding request and a chat completion.
+      sinon.assert.notCalled(openaiMock.embeddings.create)
+      sinon.assert.notCalled(openaiMock.chat.completions.create)
+    })
+  }
+
+  // Positive control beside the rejections: the same call with a real question
+  // still answers, so the guard is not rejecting everything.
+  test('still answers when a question is given', async t => {
+    const openaiMock = createOpenaiMock()
+
+    const answer = await getAnswer({
+      openai: openaiMock,
+      question: 'How do I book time off?'
+    })
+
+    t.assert.strictEqual(answer, 'Actual chat response')
+    sinon.assert.calledOnce(openaiMock.chat.completions.create)
+  })
+})

--- a/packages/slack-bot/test/messageEvents.test.js
+++ b/packages/slack-bot/test/messageEvents.test.js
@@ -75,10 +75,9 @@ const forwardedShareEvent = {
   ]
 }
 
-// A person pinning one of the bot's answers in the DM. Slack sends this on the
-// message.im subscription with a real user, real text, no bot_id and no
-// hidden, so nothing but the deny list stands between a pin notice and the bot
-// asking the model to answer it.
+// A person pinning one of the bot's answers in the DM. The notice carries a
+// real user and real text, with no bot_id and no hidden, so nothing but the
+// deny list stands between it and the bot asking the model to answer it.
 const pinnedItemNoticeEvent = {
   type: 'message',
   subtype: 'pinned_item',
@@ -284,8 +283,8 @@ describe('isTranscribableFile', () => {
   })
 
   test('accepts a voice note recognised by its subtype alone', t => {
-    // Slack marks its own voice notes with subtype: 'slack_audio', which is
-    // the more reliable of the two signals.
+    // Slack marks its own voice notes with subtype: 'slack_audio', so either
+    // signal on its own is enough.
     t.assert.strictEqual(
       isTranscribableFile({
         id: 'F0000000000',
@@ -395,10 +394,11 @@ describe('carriesQuestion', () => {
     )
   })
 
-  test('does not read the attachments of an unfurl, which nobody is waiting on', t => {
-    // The unfurl on the bot's own answer carries attachments too. It fails
-    // isPlainUserMessage first, and this keeps carriesQuestion from being the
-    // reason it stays silent.
+  test('leaves an unfurl carrying attachments to isPlainUserMessage', t => {
+    // An unfurl of the bot's own answer carries attachments too, so accepting
+    // attachments here does make it look answerable. What keeps it silent is
+    // isPlainUserMessage, which the handler consults first, and that is
+    // asserted alongside so the pair is what the coverage rests on.
     t.assert.strictEqual(
       carriesQuestion({
         ...linkUnfurlEvent,

--- a/packages/slack-bot/test/messageEvents.test.js
+++ b/packages/slack-bot/test/messageEvents.test.js
@@ -31,6 +31,30 @@ const userQuestionEvent = {
   ts: '1700000000.000200'
 }
 
+// A voice note recorded in a DM. Slack delivers a person's file upload as a
+// message event with the file_share subtype, an empty text and the file in
+// event.files, which is the shape the transcription branch in bot.js exists
+// for.
+const voiceNoteEvent = {
+  type: 'message',
+  subtype: 'file_share',
+  user: 'U0000000000',
+  text: '',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000300',
+  files: [
+    {
+      id: 'F0000000000',
+      name: 'audio_message.webm',
+      mimetype: 'audio/webm',
+      subtype: 'slack_audio',
+      url_private_download:
+        'https://files.slack.com/files-pri/T0000000000-F0000000000/download/audio_message.webm'
+    }
+  ]
+}
+
 describe('isPlainUserMessage', () => {
   test('accepts a plain direct message from a person', t => {
     t.assert.strictEqual(isPlainUserMessage(userQuestionEvent), true)
@@ -47,22 +71,70 @@ describe('isPlainUserMessage', () => {
     )
   })
 
-  test('rejects every other subtype it has not been told about', t => {
-    const otherSubtypes = [
+  test('rejects every subtype on the deny list', t => {
+    const deniedSubtypes = [
+      'bot_message',
+      'message_changed',
       'message_deleted',
       'message_replied',
+      'tombstone',
+      'ekm_access_denied',
       'channel_join',
-      'thread_broadcast',
-      'file_share'
+      'channel_leave',
+      'channel_topic',
+      'channel_purpose',
+      'channel_name',
+      'channel_archive',
+      'channel_unarchive',
+      'group_join',
+      'group_leave',
+      'group_topic',
+      'group_purpose',
+      'group_name',
+      'group_archive',
+      'group_unarchive'
     ]
 
-    for (const subtype of otherSubtypes) {
+    for (const subtype of deniedSubtypes) {
       t.assert.strictEqual(
         isPlainUserMessage({ ...userQuestionEvent, subtype }),
         false,
         `expected the ${subtype} subtype to be ignored`
       )
     }
+  })
+
+  test('accepts the subtypes that are still a person speaking', t => {
+    // file_share is a file or voice note someone uploaded, thread_broadcast is
+    // a threaded reply also sent to the channel, and me_message is a /me
+    // message. All three keep their text at event.text and are questions the
+    // bot should answer.
+    const userSubtypes = ['file_share', 'thread_broadcast', 'me_message']
+
+    for (const subtype of userSubtypes) {
+      t.assert.strictEqual(
+        isPlainUserMessage({ ...userQuestionEvent, subtype }),
+        true,
+        `expected the ${subtype} subtype to be answered`
+      )
+    }
+  })
+
+  test('accepts an unrecognised subtype, so an unknown behaves as before', t => {
+    // The list is a deny list on purpose. A subtype nobody here has seen keeps
+    // the behaviour this fix started from, an answered message, rather than
+    // becoming a new silent failure.
+    t.assert.strictEqual(
+      isPlainUserMessage({
+        ...userQuestionEvent,
+        subtype: 'a_subtype_slack_has_not_shipped_yet'
+      }),
+      true
+    )
+  })
+
+  test('accepts a voice note a person recorded in a DM', t => {
+    t.assert.strictEqual(isPlainUserMessage(voiceNoteEvent), true)
   })
 
   test('rejects an event carrying a bot_id even with no subtype', t => {
@@ -151,6 +223,10 @@ describe('carriesQuestion', () => {
       }),
       true
     )
+  })
+
+  test('accepts the voice note event, whose question is in the audio', t => {
+    t.assert.strictEqual(carriesQuestion(voiceNoteEvent), true)
   })
 
   test('rejects an event with neither text nor a file', t => {

--- a/packages/slack-bot/test/messageEvents.test.js
+++ b/packages/slack-bot/test/messageEvents.test.js
@@ -55,6 +55,31 @@ const voiceNoteEvent = {
   ]
 }
 
+// A person pinning one of the bot's answers in the DM. Slack sends this on the
+// message.im subscription with a real user, real text, no bot_id and no
+// hidden, so nothing but the deny list stands between a pin notice and the bot
+// asking the model to answer it.
+const pinnedItemNoticeEvent = {
+  type: 'message',
+  subtype: 'pinned_item',
+  user: 'U0000000000',
+  text: '<@U0000000000> pinned a message to this conversation.',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000600'
+}
+
+// A reminder notice, the same shape of thing from the same subscription.
+const reminderAddNoticeEvent = {
+  type: 'message',
+  subtype: 'reminder_add',
+  user: 'U0000000000',
+  text: 'Reminder: read the handbook.',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000700'
+}
+
 describe('isPlainUserMessage', () => {
   test('accepts a plain direct message from a person', t => {
     t.assert.strictEqual(isPlainUserMessage(userQuestionEvent), true)
@@ -71,6 +96,22 @@ describe('isPlainUserMessage', () => {
     )
   })
 
+  // The two fixtures below are written out rather than derived from the deny
+  // list, because the enumeration test that follows them is a copy of that
+  // list and so cannot notice a subtype missing from it.
+  test('rejects the pin notice a person pinning an answer produces', t => {
+    t.assert.strictEqual(isPlainUserMessage(pinnedItemNoticeEvent), false)
+
+    // Without the subtype guard this notice would be answered: it reads as a
+    // question as far as everything else here is concerned.
+    t.assert.strictEqual(carriesQuestion(pinnedItemNoticeEvent), true)
+  })
+
+  test('rejects a reminder notice', t => {
+    t.assert.strictEqual(isPlainUserMessage(reminderAddNoticeEvent), false)
+    t.assert.strictEqual(carriesQuestion(reminderAddNoticeEvent), true)
+  })
+
   test('rejects every subtype on the deny list', t => {
     const deniedSubtypes = [
       'bot_message',
@@ -79,6 +120,14 @@ describe('isPlainUserMessage', () => {
       'message_replied',
       'tombstone',
       'ekm_access_denied',
+      'pinned_item',
+      'unpinned_item',
+      'reminder_add',
+      'huddle_thread',
+      'bot_add',
+      'bot_remove',
+      'sh_room_created',
+      'app_conversation_join',
       'channel_join',
       'channel_leave',
       'channel_topic',

--- a/packages/slack-bot/test/messageEvents.test.js
+++ b/packages/slack-bot/test/messageEvents.test.js
@@ -1,0 +1,162 @@
+import { describe, test } from 'node:test'
+import {
+  carriesQuestion,
+  hasFileAttachment,
+  hasQuestionText,
+  isPlainUserMessage
+} from '../src/messageEvents.js'
+
+// The event that caused the bot to answer its own default question: Slack
+// unfurled a link in the bot's answer and sent the edit back as a
+// message_changed event, whose text lives at event.message.text.
+const linkUnfurlEvent = {
+  type: 'message',
+  subtype: 'message_changed',
+  message: {
+    bot_id: 'B0000000000',
+    text: 'To get access, you should install <https://example.com/handbook>'
+  },
+  hidden: true,
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000100'
+}
+
+const userQuestionEvent = {
+  type: 'message',
+  user: 'U0000000000',
+  text: 'How do I book time off?',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000200'
+}
+
+describe('isPlainUserMessage', () => {
+  test('accepts a plain direct message from a person', t => {
+    t.assert.strictEqual(isPlainUserMessage(userQuestionEvent), true)
+  })
+
+  test('rejects the message_changed event a link unfurl produces', t => {
+    t.assert.strictEqual(isPlainUserMessage(linkUnfurlEvent), false)
+  })
+
+  test('rejects a bot_message, as the previous guard did', t => {
+    t.assert.strictEqual(
+      isPlainUserMessage({ ...userQuestionEvent, subtype: 'bot_message' }),
+      false
+    )
+  })
+
+  test('rejects every other subtype it has not been told about', t => {
+    const otherSubtypes = [
+      'message_deleted',
+      'message_replied',
+      'channel_join',
+      'thread_broadcast',
+      'file_share'
+    ]
+
+    for (const subtype of otherSubtypes) {
+      t.assert.strictEqual(
+        isPlainUserMessage({ ...userQuestionEvent, subtype }),
+        false,
+        `expected the ${subtype} subtype to be ignored`
+      )
+    }
+  })
+
+  test('rejects an event carrying a bot_id even with no subtype', t => {
+    t.assert.strictEqual(
+      isPlainUserMessage({ ...userQuestionEvent, bot_id: 'B0000000000' }),
+      false
+    )
+  })
+
+  test('rejects a hidden event even with no subtype and no bot_id', t => {
+    t.assert.strictEqual(
+      isPlainUserMessage({ ...userQuestionEvent, hidden: true }),
+      false
+    )
+  })
+
+  test('rejects a missing event rather than throwing', t => {
+    t.assert.strictEqual(isPlainUserMessage(undefined), false)
+  })
+})
+
+describe('hasQuestionText', () => {
+  test('accepts text a person typed', t => {
+    t.assert.strictEqual(hasQuestionText(userQuestionEvent), true)
+  })
+
+  test('rejects an absent text field', t => {
+    t.assert.strictEqual(
+      hasQuestionText({ ...userQuestionEvent, text: undefined }),
+      false
+    )
+  })
+
+  test('rejects an empty text field', t => {
+    t.assert.strictEqual(
+      hasQuestionText({ ...userQuestionEvent, text: '' }),
+      false
+    )
+  })
+
+  test('rejects text that is only whitespace', t => {
+    t.assert.strictEqual(
+      hasQuestionText({ ...userQuestionEvent, text: '   \n\t ' }),
+      false
+    )
+  })
+
+  test('does not read the text a message_changed event nests', t => {
+    // event.message.text is where the unfurled copy keeps its text. Reading it
+    // is what would make the bot answer its own message.
+    t.assert.strictEqual(hasQuestionText(linkUnfurlEvent), false)
+  })
+})
+
+describe('hasFileAttachment', () => {
+  test('accepts an event with a file to transcribe', t => {
+    t.assert.strictEqual(
+      hasFileAttachment({ ...userQuestionEvent, files: [{ id: 'F000' }] }),
+      true
+    )
+  })
+
+  test('rejects an event with no files field', t => {
+    t.assert.strictEqual(hasFileAttachment(userQuestionEvent), false)
+  })
+
+  test('rejects an event with an empty files array', t => {
+    t.assert.strictEqual(
+      hasFileAttachment({ ...userQuestionEvent, files: [] }),
+      false
+    )
+  })
+})
+
+describe('carriesQuestion', () => {
+  test('accepts typed text with no files', t => {
+    t.assert.strictEqual(carriesQuestion(userQuestionEvent), true)
+  })
+
+  test('accepts a file with no text, which transcription may turn into one', t => {
+    t.assert.strictEqual(
+      carriesQuestion({
+        ...userQuestionEvent,
+        text: '',
+        files: [{ id: 'F000' }]
+      }),
+      true
+    )
+  })
+
+  test('rejects an event with neither text nor a file', t => {
+    t.assert.strictEqual(
+      carriesQuestion({ ...userQuestionEvent, text: '' }),
+      false
+    )
+  })
+})

--- a/packages/slack-bot/test/messageEvents.test.js
+++ b/packages/slack-bot/test/messageEvents.test.js
@@ -3,7 +3,8 @@ import {
   carriesQuestion,
   hasFileAttachment,
   hasQuestionText,
-  isPlainUserMessage
+  isPlainUserMessage,
+  isTranscribableFile
 } from '../src/messageEvents.js'
 
 // The event that caused the bot to answer its own default question: Slack
@@ -255,6 +256,80 @@ describe('hasFileAttachment', () => {
       hasFileAttachment({ ...userQuestionEvent, files: [] }),
       false
     )
+  })
+})
+
+describe('isTranscribableFile', () => {
+  test('accepts the voice note Slack records in a DM', t => {
+    t.assert.strictEqual(isTranscribableFile(voiceNoteEvent.files[0]), true)
+  })
+
+  test('accepts a voice note recognised by its subtype alone', t => {
+    // Slack marks its own voice notes with subtype: 'slack_audio', which is
+    // the more reliable of the two signals.
+    t.assert.strictEqual(
+      isTranscribableFile({
+        id: 'F0000000000',
+        subtype: 'slack_audio',
+        url_private_download: 'https://files.slack.com/audio_message.webm'
+      }),
+      true
+    )
+  })
+
+  test('rejects a document, which has no audio to transcribe', t => {
+    // A PDF or a screenshot was downloaded and uploaded to OpenAI's audio
+    // endpoint for nothing before Whisper rejected it, which for confidential
+    // client content is a send that should never have happened.
+    t.assert.strictEqual(
+      isTranscribableFile({
+        id: 'F0000000001',
+        name: 'contract.pdf',
+        mimetype: 'application/pdf',
+        url_private_download: 'https://files.slack.com/contract.pdf'
+      }),
+      false
+    )
+  })
+
+  test('rejects a video, whose soundtrack is not the question', t => {
+    // Whisper accepts a screen recording's audio track, so this one
+    // transcribed successfully and overwrote the question the person typed.
+    t.assert.strictEqual(
+      isTranscribableFile({
+        id: 'F0000000002',
+        name: 'screen-recording.mp4',
+        mimetype: 'video/mp4',
+        url_private_download: 'https://files.slack.com/screen-recording.mp4'
+      }),
+      false
+    )
+  })
+
+  test('rejects an audio file Slack served no download URL for', t => {
+    // Slack Connect and restricted files arrive as a stub, and hidden_by_limit
+    // and external-mode files lack the URL too. new URL(undefined) threw a
+    // TypeError, which surfaced as the generic internal failure.
+    t.assert.strictEqual(
+      isTranscribableFile({
+        id: 'F0000000003',
+        mimetype: 'audio/webm',
+        file_access: 'check_file_info'
+      }),
+      false
+    )
+    t.assert.strictEqual(
+      isTranscribableFile({
+        id: 'F0000000003',
+        mimetype: 'audio/webm',
+        url_private_download: ''
+      }),
+      false
+    )
+  })
+
+  test('rejects a missing file rather than throwing', t => {
+    t.assert.strictEqual(isTranscribableFile(undefined), false)
   })
 })
 

--- a/packages/slack-bot/test/messageEvents.test.js
+++ b/packages/slack-bot/test/messageEvents.test.js
@@ -56,6 +56,25 @@ const voiceNoteEvent = {
   ]
 }
 
+// Share or Forward used on an existing message into the bot's DM with no
+// comment typed. The shared content arrives in attachments, the text is empty,
+// and there are no files.
+const forwardedShareEvent = {
+  type: 'message',
+  user: 'U0000000000',
+  text: '',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.001100',
+  attachments: [
+    {
+      is_share: true,
+      author_name: 'Someone Else',
+      text: 'Time off is booked in the HR tool.'
+    }
+  ]
+}
+
 // A person pinning one of the bot's answers in the DM. Slack sends this on the
 // message.im subscription with a real user, real text, no bot_id and no
 // hidden, so nothing but the deny list stands between a pin notice and the bot
@@ -356,6 +375,42 @@ describe('carriesQuestion', () => {
   test('rejects an event with neither text nor a file', t => {
     t.assert.strictEqual(
       carriesQuestion({ ...userQuestionEvent, text: '' }),
+      false
+    )
+  })
+
+  // Share or Forward with no comment typed sends an empty text, no files, and
+  // the shared message in attachments. Returning false here dropped the event
+  // before the reaction, so the person was left waiting with nothing at all to
+  // look at. The handler replies asking for a question rather than answering
+  // content nobody framed as one.
+  test('accepts a forwarded message, which someone is waiting on a reply to', t => {
+    t.assert.strictEqual(carriesQuestion(forwardedShareEvent), true)
+  })
+
+  test('rejects an empty attachments array', t => {
+    t.assert.strictEqual(
+      carriesQuestion({ ...userQuestionEvent, text: '', attachments: [] }),
+      false
+    )
+  })
+
+  test('does not read the attachments of an unfurl, which nobody is waiting on', t => {
+    // The unfurl on the bot's own answer carries attachments too. It fails
+    // isPlainUserMessage first, and this keeps carriesQuestion from being the
+    // reason it stays silent.
+    t.assert.strictEqual(
+      carriesQuestion({
+        ...linkUnfurlEvent,
+        attachments: [{ text: 'The Nearform handbook' }]
+      }),
+      true
+    )
+    t.assert.strictEqual(
+      isPlainUserMessage({
+        ...linkUnfurlEvent,
+        attachments: [{ text: 'The Nearform handbook' }]
+      }),
       false
     )
   })

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -1,0 +1,258 @@
+import { beforeEach, describe, test, mock } from 'node:test'
+import sinon from 'sinon'
+
+// bot.js builds an ExpressReceiver, a Bolt App and an OpenAI client as it
+// loads, and registers the message listener on the App. Faking those three
+// gives the listener itself, which is where the decisions this file is about
+// are made. getAnswer.js and utils.js are faked as well: the first loads the
+// embeddings as it imports, and transcribe in the second downloads the audio
+// over the network. mock.module registers a specifier once per process, so this
+// lives in its own test file.
+
+const registeredEventHandlers = new Map()
+
+// Mirrors the real getAnswer, which throws rather than inventing a question.
+// Without that, a handler that reached it with nothing to ask would look fine
+// here and post the generic error in production.
+const getAnswerMock = sinon.spy(async ({ question }) => {
+  if (typeof question !== 'string' || question.trim().length === 0) {
+    throw new Error('getAnswer requires a question')
+  }
+  return answerFromGetAnswer
+})
+const transcribeMock = sinon.spy(async () => transcriptionResult)
+
+let answerFromGetAnswer = 'You book time off in the HR tool.'
+let transcriptionResult = ''
+
+class AppMock {
+  event(eventName, handler) {
+    registeredEventHandlers.set(eventName, handler)
+  }
+  shortcut() {}
+  error() {}
+}
+
+class ExpressReceiverMock {
+  app = { get: () => {} }
+}
+
+mock.module('@slack/bolt', {
+  defaultExport: { App: AppMock, ExpressReceiver: ExpressReceiverMock }
+})
+
+mock.module('openai', {
+  defaultExport: class OpenAIMock {}
+})
+
+mock.module('../src/getAnswer.js', {
+  namedExports: {
+    getAnswer: getAnswerMock,
+    initialize: async () => {}
+  }
+})
+
+mock.module('../src/utils.js', {
+  namedExports: { transcribe: transcribeMock }
+})
+
+await import('../src/bot.js')
+
+const messageHandler = registeredEventHandlers.get('message')
+
+// The generic failure message bot.js posts when something went wrong. Named
+// here so a test can assert it was not the one a user got.
+const genericErrorResponse =
+  'It appears I have run into an issue looking up an answer for you. Please try again'
+
+function createClientMock() {
+  return {
+    reactions: { add: sinon.spy(async () => {}) },
+    users: {
+      info: sinon.spy(async () => ({ user: { locale: 'en-GB' } }))
+    },
+    chat: { postMessage: sinon.spy(async () => {}) }
+  }
+}
+
+function postedMessages(client) {
+  return client.chat.postMessage.args.map(([message]) => message.text)
+}
+
+const typedQuestionEvent = {
+  type: 'message',
+  user: 'U0000000000',
+  text: 'How do I book time off?',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000200'
+}
+
+const voiceNoteEvent = {
+  type: 'message',
+  subtype: 'file_share',
+  user: 'U0000000000',
+  text: '',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000300',
+  files: [
+    {
+      id: 'F0000000000',
+      mimetype: 'audio/webm',
+      url_private_download:
+        'https://files.slack.com/files-pri/T0000000000-F0000000000/download/audio_message.webm'
+    }
+  ]
+}
+
+// The event from issue #983: Slack unfurled a link in the bot's own answer and
+// sent the edit back as a message event.
+const linkUnfurlEvent = {
+  type: 'message',
+  subtype: 'message_changed',
+  hidden: true,
+  message: {
+    bot_id: 'B0000000000',
+    text: 'To get access, install <https://example.com/handbook>'
+  },
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000100'
+}
+
+// Another app posting into the DM. Unlike the unfurl above this one does carry
+// top-level text, so the subtype guard is the only thing standing between it
+// and an answer.
+const otherBotMessageEvent = {
+  type: 'message',
+  subtype: 'bot_message',
+  bot_id: 'B0000000001',
+  text: 'Deploy finished successfully',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000400'
+}
+
+beforeEach(() => {
+  getAnswerMock.resetHistory()
+  transcribeMock.resetHistory()
+  answerFromGetAnswer = 'You book time off in the HR tool.'
+  transcriptionResult = ''
+})
+
+describe('the message handler', () => {
+  test('registers itself for the message event', t => {
+    t.assert.strictEqual(typeof messageHandler, 'function')
+  })
+
+  test('answers a question a person typed', async t => {
+    const client = createClientMock()
+
+    await messageHandler({ event: typedQuestionEvent, client })
+
+    sinon.assert.calledOnce(getAnswerMock)
+    t.assert.strictEqual(
+      getAnswerMock.firstCall.args[0].question,
+      typedQuestionEvent.text
+    )
+    t.assert.ok(
+      postedMessages(client).includes(answerFromGetAnswer),
+      'the answer should be posted'
+    )
+  })
+
+  test('leaves no trace at all on the link unfurl of its own answer', async t => {
+    const client = createClientMock()
+
+    await messageHandler({ event: linkUnfurlEvent, client })
+
+    sinon.assert.notCalled(getAnswerMock)
+    sinon.assert.notCalled(client.reactions.add)
+    sinon.assert.notCalled(client.chat.postMessage)
+    t.assert.deepStrictEqual(postedMessages(client), [])
+  })
+
+  test('ignores another bot posting text into the DM', async t => {
+    const client = createClientMock()
+
+    await messageHandler({ event: otherBotMessageEvent, client })
+
+    sinon.assert.notCalled(getAnswerMock)
+    sinon.assert.notCalled(client.reactions.add)
+    t.assert.deepStrictEqual(postedMessages(client), [])
+  })
+
+  test('transcribes a voice note and answers what was said', async t => {
+    transcriptionResult = 'How do I book time off?'
+    const client = createClientMock()
+
+    await messageHandler({ event: voiceNoteEvent, client })
+
+    sinon.assert.calledOnce(transcribeMock)
+    t.assert.strictEqual(
+      transcribeMock.firstCall.args[0],
+      voiceNoteEvent.files[0]
+    )
+
+    sinon.assert.calledOnce(getAnswerMock)
+    t.assert.strictEqual(
+      getAnswerMock.firstCall.args[0].question,
+      transcriptionResult
+    )
+
+    const posted = postedMessages(client)
+    t.assert.ok(
+      posted.some(text => text.includes(transcriptionResult)),
+      'the acknowledgement should quote what was heard'
+    )
+    t.assert.ok(
+      posted.includes(answerFromGetAnswer),
+      'the answer should be posted'
+    )
+  })
+
+  test('tells the user the audio was not understood rather than posting the generic error', async t => {
+    transcriptionResult = ''
+    const client = createClientMock()
+
+    await messageHandler({ event: voiceNoteEvent, client })
+
+    const posted = postedMessages(client)
+    t.assert.strictEqual(
+      posted.length,
+      1,
+      `exactly one message should be posted, got ${JSON.stringify(posted)}`
+    )
+    t.assert.match(posted[0], /could not make out any words in that recording/i)
+    t.assert.match(posted[0], /type your question/i)
+    t.assert.ok(
+      !posted.includes(genericErrorResponse),
+      'an unintelligible recording is not an internal failure'
+    )
+
+    // Nothing to ask, so nothing is asked. getAnswer now throws on a missing
+    // question, which is what produced the generic error.
+    sinon.assert.notCalled(getAnswerMock)
+  })
+
+  test('falls back to the text alongside a file when the audio yields nothing', async t => {
+    transcriptionResult = ''
+    const client = createClientMock()
+
+    await messageHandler({
+      event: { ...voiceNoteEvent, text: 'How do I book time off?' },
+      client
+    })
+
+    sinon.assert.calledOnce(getAnswerMock)
+    t.assert.strictEqual(
+      getAnswerMock.firstCall.args[0].question,
+      'How do I book time off?'
+    )
+    t.assert.ok(
+      postedMessages(client).includes(answerFromGetAnswer),
+      'the answer should be posted'
+    )
+  })
+})

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -237,6 +237,26 @@ const otherBotMessageEvent = {
   ts: '1700000000.000400'
 }
 
+// Share or Forward used on an existing message into the bot's DM with no
+// comment typed: an empty text, no files, and the shared message in
+// attachments. The handler used to return before the reaction, so the person
+// was left waiting with nothing at all to look at.
+const forwardedShareEvent = {
+  type: 'message',
+  user: 'U0000000000',
+  text: '',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.001100',
+  attachments: [
+    {
+      is_share: true,
+      author_name: 'Someone Else',
+      text: 'Time off is booked in the HR tool.'
+    }
+  ]
+}
+
 // The notice Slack sends when someone pins a message in the conversation.
 const pinnedItemNoticeEvent = {
   type: 'message',
@@ -385,6 +405,47 @@ describe('the message handler', () => {
     const client = createClientMock()
 
     await messageHandler({ event: pinnedItemNoticeEvent, client })
+
+    sinon.assert.notCalled(getAnswerMock)
+    sinon.assert.notCalled(client.reactions.add)
+    t.assert.deepStrictEqual(postedMessages(client), [])
+  })
+
+  test('asks for a question when a message is forwarded with no comment', async t => {
+    const client = createClientMock()
+
+    await messageHandler({ event: forwardedShareEvent, client })
+
+    sinon.assert.calledOnce(client.reactions.add)
+
+    const posted = postedMessages(client)
+    t.assert.strictEqual(
+      posted.length,
+      1,
+      `exactly one message should be posted, got ${JSON.stringify(posted)}`
+    )
+    t.assert.match(posted[0], /type your question/i)
+
+    // The shared content is deliberately not treated as the question:
+    // answering something the sender never asked is a different feature.
+    sinon.assert.notCalled(getAnswerMock)
+    sinon.assert.notCalled(transcribeMock)
+    t.assert.ok(!posted.includes(genericErrorResponse))
+  })
+
+  test('still leaves no trace on an unfurl that carries attachments', async t => {
+    // The reply above must not reach the events nobody is waiting on. An
+    // unfurl of the bot's own answer carries attachments as well, and issue
+    // #983 depends on it staying silent.
+    const client = createClientMock()
+
+    await messageHandler({
+      event: {
+        ...linkUnfurlEvent,
+        attachments: [{ text: 'The Nearform handbook' }]
+      },
+      client
+    })
 
     sinon.assert.notCalled(getAnswerMock)
     sinon.assert.notCalled(client.reactions.add)

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -395,6 +395,27 @@ describe('the message handler', () => {
     sinon.assert.notCalled(getAnswerMock)
   })
 
+  // The notice and its return used to sit inside the try/catch around
+  // transcribe, so a Slack failure posting it was logged as a transcription
+  // error, skipped the return, and left the user with the generic failure the
+  // comment above that post says must not be shown for a silent recording.
+  test('does not report an internal failure when the silent recording notice cannot be posted', async t => {
+    transcriptionResult = ''
+    const client = createClientMock()
+    const postError = new Error('internal_error')
+    rejectPostsMatching(client, /could not make out any words/, postError)
+    t.mock.method(console, 'error', () => {})
+
+    await messageHandler({ event: voiceNoteEvent, client })
+    await settleFireAndForgetCalls()
+
+    t.assert.ok(
+      !postedMessages(client).includes(genericErrorResponse),
+      'a silent recording is not an internal failure, whatever Slack does with the notice'
+    )
+    sinon.assert.notCalled(getAnswerMock)
+  })
+
   // Whisper with response_format: 'text' returns only whitespace for audio
   // that contains no speech, and a whitespace-only string is truthy, so the
   // "we heard something" path was taken with nothing in it. transcribe now

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -92,6 +92,25 @@ function postedMessages(client) {
   return client.chat.postMessage.args.map(([message]) => message.text)
 }
 
+// Makes one of the posts fail while the rest keep working, so a test can pick
+// out the interim acknowledgement without failing the answer as well.
+function rejectPostsMatching(client, pattern, error) {
+  const succeedingPostMessage = client.chat.postMessage
+  client.chat.postMessage = sinon.spy(async message => {
+    if (pattern.test(message.text)) {
+      throw error
+    }
+    return succeedingPostMessage(message)
+  })
+}
+
+// An unhandled rejection is reported on the turn after the promise settles, so
+// a fire-and-forget call with no catch has to be given that turn to blow up in
+// before the test ends.
+function settleFireAndForgetCalls() {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
 const typedQuestionEvent = {
   type: 'message',
   user: 'U0000000000',
@@ -196,6 +215,73 @@ describe('the message handler', () => {
     t.assert.ok(
       postedMessages(client).includes(answerFromGetAnswer),
       'the answer should be posted'
+    )
+  })
+
+  // The three Slack calls the handler deliberately does not wait on. Each one
+  // used to be started with no catch, so a WebAPIPlatformError (already_reacted
+  // on a Slack redelivery, msg_too_long, a 429 after retries) became an
+  // unhandled rejection, which functions-framework turns into a process exit
+  // that kills every in-flight request.
+  test('answers anyway when the reaction it does not wait for is rejected', async t => {
+    const client = createClientMock()
+    const reactionError = new Error('already_reacted')
+    client.reactions.add = sinon.spy(async () => {
+      throw reactionError
+    })
+    const consoleError = t.mock.method(console, 'error', () => {})
+
+    await messageHandler({ event: typedQuestionEvent, client })
+    await settleFireAndForgetCalls()
+
+    t.assert.ok(
+      postedMessages(client).includes(answerFromGetAnswer),
+      'the answer should still be posted'
+    )
+    t.assert.ok(
+      consoleError.mock.calls.some(call =>
+        call.arguments.includes(reactionError)
+      ),
+      'the rejection should be logged rather than left unhandled'
+    )
+  })
+
+  test('answers anyway when the interim acknowledgement is rejected', async t => {
+    const client = createClientMock()
+    const postError = new Error('msg_too_long')
+    rejectPostsMatching(client, /Thanks for your question/, postError)
+    const consoleError = t.mock.method(console, 'error', () => {})
+
+    await messageHandler({ event: typedQuestionEvent, client })
+    await settleFireAndForgetCalls()
+
+    t.assert.ok(
+      postedMessages(client).includes(answerFromGetAnswer),
+      'the answer should still be posted'
+    )
+    t.assert.ok(
+      consoleError.mock.calls.some(call => call.arguments.includes(postError)),
+      'the rejection should be logged rather than left unhandled'
+    )
+  })
+
+  test('answers anyway when the transcription acknowledgement is rejected', async t => {
+    transcriptionResult = 'How do I book time off?'
+    const client = createClientMock()
+    const postError = new Error('msg_too_long')
+    rejectPostsMatching(client, /You asked/, postError)
+    const consoleError = t.mock.method(console, 'error', () => {})
+
+    await messageHandler({ event: voiceNoteEvent, client })
+    await settleFireAndForgetCalls()
+
+    t.assert.ok(
+      postedMessages(client).includes(answerFromGetAnswer),
+      'the answer should still be posted'
+    )
+    t.assert.ok(
+      consoleError.mock.calls.some(call => call.arguments.includes(postError)),
+      'the rejection should be logged rather than left unhandled'
     )
   })
 

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -143,6 +143,18 @@ const otherBotMessageEvent = {
   ts: '1700000000.000400'
 }
 
+// The subtype deny list is deliberately not an allow list, so a subtype we do
+// not recognise is let through to be answered. This one carries neither text
+// nor a file, which leaves nothing to answer and nobody waiting on a reply.
+const unrecognisedSubtypeWithNothingToAnswerEvent = {
+  type: 'message',
+  subtype: 'some_subtype_slack_added_later',
+  user: 'U0000000000',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000500'
+}
+
 beforeEach(() => {
   getAnswerMock.resetHistory()
   transcribeMock.resetHistory()
@@ -190,6 +202,20 @@ describe('the message handler', () => {
 
     sinon.assert.notCalled(getAnswerMock)
     sinon.assert.notCalled(client.reactions.add)
+    t.assert.deepStrictEqual(postedMessages(client), [])
+  })
+
+  test('leaves no trace when an unrecognised subtype carries nothing to answer', async t => {
+    const client = createClientMock()
+
+    await messageHandler({
+      event: unrecognisedSubtypeWithNothingToAnswerEvent,
+      client
+    })
+
+    sinon.assert.notCalled(getAnswerMock)
+    sinon.assert.notCalled(client.reactions.add)
+    sinon.assert.notCalled(client.chat.postMessage)
     t.assert.deepStrictEqual(postedMessages(client), [])
   })
 

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -309,8 +309,9 @@ describe('the message handler', () => {
     )
   })
 
-  // The three Slack calls the handler deliberately does not wait on. Each one
-  // used to be started with no catch, so a WebAPIPlatformError (already_reacted
+  // Three of the Slack calls the handler deliberately does not wait on: the
+  // reaction, and the two acknowledgements that existed before this branch.
+  // Each was started with no catch, so a WebAPIPlatformError (already_reacted
   // on a Slack redelivery, msg_too_long, a 429 after retries) became an
   // unhandled rejection, which functions-framework turns into a process exit
   // that kills every in-flight request.
@@ -364,6 +365,25 @@ describe('the message handler', () => {
     const consoleError = t.mock.method(console, 'error', () => {})
 
     await messageHandler({ event: voiceNoteEvent, client })
+    await settleFireAndForgetCalls()
+
+    t.assert.ok(
+      postedMessages(client).includes(answerFromGetAnswer),
+      'the answer should still be posted'
+    )
+    t.assert.ok(
+      consoleError.mock.calls.some(call => call.arguments.includes(postError)),
+      'the rejection should be logged rather than left unhandled'
+    )
+  })
+
+  test('answers anyway when the attachment fallback acknowledgement is rejected', async t => {
+    const client = createClientMock()
+    const postError = new Error('msg_too_long')
+    rejectPostsMatching(client, attachmentFallbackNotice, postError)
+    const consoleError = t.mock.method(console, 'error', () => {})
+
+    await messageHandler({ event: documentUploadEvent, client })
     await settleFireAndForgetCalls()
 
     t.assert.ok(

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -188,6 +188,34 @@ const screenRecordingEvent = {
   ]
 }
 
+// A document and a voice note uploaded in one message, the document first.
+// Looking only at event.files[0] found the document, so the person was told
+// their attachment could not be read while the recording was ignored.
+const documentAndVoiceNoteEvent = {
+  type: 'message',
+  subtype: 'file_share',
+  user: 'U0000000000',
+  text: '',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.001200',
+  files: [
+    {
+      id: 'F0000000004',
+      name: 'contract.pdf',
+      mimetype: 'application/pdf',
+      url_private_download:
+        'https://files.slack.com/files-pri/T0000000000-F0000000004/download/contract.pdf'
+    },
+    {
+      id: 'F0000000005',
+      mimetype: 'audio/webm',
+      url_private_download:
+        'https://files.slack.com/files-pri/T0000000000-F0000000005/download/audio_message.webm'
+    }
+  ]
+}
+
 // What Slack sends for a file the app may not download: a Slack Connect or
 // restricted file, or one hidden by a free plan's storage limit. There is no
 // url_private_download, and new URL(undefined) threw a TypeError.
@@ -740,6 +768,32 @@ describe('the message handler', () => {
       !posted.includes(genericErrorResponse),
       'a file Slack will not serve us is not an internal failure'
     )
+  })
+
+  test('transcribes the voice note in a multi-file upload it is not first in', async t => {
+    transcriptionResult = 'How do I book time off?'
+    const client = createClientMock()
+
+    await messageHandler({ event: documentAndVoiceNoteEvent, client })
+
+    sinon.assert.calledOnce(transcribeMock)
+    t.assert.strictEqual(
+      transcribeMock.firstCall.args[0].id,
+      'F0000000005',
+      'the recording should be the file that is transcribed, not the document'
+    )
+    sinon.assert.calledOnce(getAnswerMock)
+    t.assert.strictEqual(
+      getAnswerMock.firstCall.args[0].question,
+      transcriptionResult
+    )
+
+    const posted = postedMessages(client)
+    t.assert.ok(
+      !posted.some(text => unreadableAttachmentNotice.test(text)),
+      `the recording was read, so nothing should say otherwise, got ${JSON.stringify(posted)}`
+    )
+    t.assert.ok(posted.includes(answerFromGetAnswer))
   })
 
   // The boundary of the fallback above: with nothing typed there is no question

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -27,7 +27,11 @@ const transcribeMock = sinon.spy(async () => {
   if (transcriptionRejection) {
     throw transcriptionRejection
   }
-  return transcriptionResult
+  // The real transcribe trims what it returns, so the empty string means "no
+  // words were heard". Trimming here keeps the fake to that contract, which is
+  // what the handler branches on. The trim itself is covered in
+  // transcribe.test.js.
+  return transcriptionResult.trim()
 })
 
 let answerFromGetAnswer = 'You book time off in the HR tool.'
@@ -220,8 +224,9 @@ describe('the message handler', () => {
   })
 
   test('transcribes a voice note and answers what was said', async t => {
-    // Whisper's text format newline-terminates what it returns, so the value
-    // reaching getAnswer has to be the trimmed one.
+    // Whisper's text format newline-terminates what it returns, and transcribe
+    // trims it, so what reaches getAnswer and the acknowledgement is the words
+    // and nothing else.
     transcriptionResult = 'How do I book time off?\n'
     const client = createClientMock()
 
@@ -279,11 +284,11 @@ describe('the message handler', () => {
     sinon.assert.notCalled(getAnswerMock)
   })
 
-  // Whisper with response_format: 'text' returns a plain string, and returns
-  // only whitespace for audio that contains no speech. A whitespace-only string
-  // is truthy, so branching on the untrimmed value took the "we heard
-  // something" path with nothing in it.
-  test('treats a whitespace-only transcription as no words heard', async t => {
+  // Whisper with response_format: 'text' returns only whitespace for audio
+  // that contains no speech, and a whitespace-only string is truthy, so the
+  // "we heard something" path was taken with nothing in it. transcribe now
+  // trims, and this covers the whole way through the handler.
+  test('treats a recording that transcribes to only whitespace as no words heard', async t => {
     transcriptionResult = ' \n '
     const client = createClientMock()
 

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -78,6 +78,12 @@ const messageHandler = registeredEventHandlers.get('message')
 const genericErrorResponse =
   'It appears I have run into an issue looking up an answer for you. Please try again'
 
+// The acknowledgement on the paths where the attachment was no use but the
+// person typed a question alongside it, and the reply when the attachment was
+// no use and there is nothing typed to fall back on.
+const attachmentFallbackNotice = /could not get anything from that attachment/i
+const unreadableAttachmentNotice = /could not read that attachment/i
+
 function createClientMock() {
   return {
     reactions: { add: sinon.spy(async () => {}) },
@@ -134,6 +140,71 @@ const voiceNoteEvent = {
       mimetype: 'audio/webm',
       url_private_download:
         'https://files.slack.com/files-pri/T0000000000-F0000000000/download/audio_message.webm'
+    }
+  ]
+}
+
+// A document upload with the question typed alongside it. Whisper has nothing
+// to transcribe here, and the file is potentially confidential client content
+// that should not be sent to OpenAI at all.
+const documentUploadEvent = {
+  type: 'message',
+  subtype: 'file_share',
+  user: 'U0000000000',
+  text: 'How do I book time off?',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000800',
+  files: [
+    {
+      id: 'F0000000001',
+      name: 'contract.pdf',
+      mimetype: 'application/pdf',
+      url_private_download:
+        'https://files.slack.com/files-pri/T0000000000-F0000000001/download/contract.pdf'
+    }
+  ]
+}
+
+// A screen recording with the question typed alongside it. Whisper accepts a
+// video's audio track, so this one transcribed successfully and answered the
+// soundtrack instead of the question.
+const screenRecordingEvent = {
+  type: 'message',
+  subtype: 'file_share',
+  user: 'U0000000000',
+  text: 'How do I book time off?',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000900',
+  files: [
+    {
+      id: 'F0000000002',
+      name: 'screen-recording.mp4',
+      mimetype: 'video/mp4',
+      url_private_download:
+        'https://files.slack.com/files-pri/T0000000000-F0000000002/download/screen-recording.mp4'
+    }
+  ]
+}
+
+// What Slack sends for a file the app may not download: a Slack Connect or
+// restricted file, or one hidden by a free plan's storage limit. There is no
+// url_private_download, and new URL(undefined) threw a TypeError.
+const restrictedFileEvent = {
+  type: 'message',
+  subtype: 'file_share',
+  user: 'U0000000000',
+  text: '',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.001000',
+  files: [
+    {
+      id: 'F0000000003',
+      created: 1700000000,
+      timestamp: 1700000000,
+      file_access: 'check_file_info'
     }
   ]
 }
@@ -479,15 +550,23 @@ describe('the message handler', () => {
       getAnswerMock.firstCall.args[0].question,
       'How do I book time off?'
     )
+
+    const posted = postedMessages(client)
+    // Without this the person waited the whole embeddings and completion round
+    // trip on a bare thumbsup, and was never told the recording was no use.
     t.assert.ok(
-      postedMessages(client).includes(answerFromGetAnswer),
+      posted.some(text => attachmentFallbackNotice.test(text)),
+      `the fallback should be acknowledged, got ${JSON.stringify(posted)}`
+    )
+    t.assert.ok(
+      posted.includes(answerFromGetAnswer),
       'the answer should be posted'
     )
   })
 
-  // A user attaches a PDF or a screenshot and types the question alongside it.
-  // Whisper rejects the non-audio body, which is a failure of the file, not of
-  // the question sitting in event.text.
+  // A real audio file that Whisper would not transcribe: an API error, or a
+  // download that failed. That is a failure of the file, not of the question
+  // sitting in event.text.
   test('falls back to the text alongside a file when the transcription fails', async t => {
     transcriptionRejection = new Error('Whisper rejected the uploaded file')
     const client = createClientMock()
@@ -506,12 +585,79 @@ describe('the message handler', () => {
 
     const posted = postedMessages(client)
     t.assert.ok(
+      posted.some(text => attachmentFallbackNotice.test(text)),
+      `the fallback should be acknowledged, got ${JSON.stringify(posted)}`
+    )
+    t.assert.ok(
       posted.includes(answerFromGetAnswer),
       `the answer should be posted, got ${JSON.stringify(posted)}`
     )
     t.assert.ok(
       !posted.includes(genericErrorResponse),
       'the typed question is answerable, so nothing has gone wrong'
+    )
+  })
+
+  test('answers the typed question and never sends a document to Whisper', async t => {
+    const client = createClientMock()
+
+    await messageHandler({ event: documentUploadEvent, client })
+
+    sinon.assert.notCalled(transcribeMock)
+    sinon.assert.calledOnce(getAnswerMock)
+    t.assert.strictEqual(
+      getAnswerMock.firstCall.args[0].question,
+      documentUploadEvent.text
+    )
+
+    const posted = postedMessages(client)
+    t.assert.ok(
+      posted.some(text => attachmentFallbackNotice.test(text)),
+      `the user should be told the file was not read, got ${JSON.stringify(posted)}`
+    )
+    t.assert.ok(posted.includes(answerFromGetAnswer))
+    t.assert.ok(!posted.includes(genericErrorResponse))
+  })
+
+  test('answers the typed question rather than a video soundtrack', async t => {
+    // Whisper transcribes a screen recording's audio track happily, and that
+    // transcript replaced the question the person had typed.
+    transcriptionResult = 'so then you click the green button'
+    const client = createClientMock()
+
+    await messageHandler({ event: screenRecordingEvent, client })
+
+    sinon.assert.notCalled(transcribeMock)
+    sinon.assert.calledOnce(getAnswerMock)
+    t.assert.strictEqual(
+      getAnswerMock.firstCall.args[0].question,
+      screenRecordingEvent.text
+    )
+  })
+
+  test('says it could not read an attachment sent with nothing typed', async t => {
+    const client = createClientMock()
+
+    await messageHandler({ event: restrictedFileEvent, client })
+
+    sinon.assert.notCalled(transcribeMock)
+    sinon.assert.notCalled(getAnswerMock)
+    // The person is waiting on something, so the reaction and a reply both
+    // matter: this is a user-side situation, not an event we should not have
+    // been sent.
+    sinon.assert.calledOnce(client.reactions.add)
+
+    const posted = postedMessages(client)
+    t.assert.strictEqual(
+      posted.length,
+      1,
+      `exactly one message should be posted, got ${JSON.stringify(posted)}`
+    )
+    t.assert.match(posted[0], unreadableAttachmentNotice)
+    t.assert.match(posted[0], /type your question/i)
+    t.assert.ok(
+      !posted.includes(genericErrorResponse),
+      'a file Slack will not serve us is not an internal failure'
     )
   })
 

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -20,10 +20,19 @@ const getAnswerMock = sinon.spy(async ({ question }) => {
   }
   return answerFromGetAnswer
 })
-const transcribeMock = sinon.spy(async () => transcriptionResult)
+// Transcription can fail outright as well as come back empty: Whisper rejects
+// a body that is not audio, which is what a PDF or a screenshot upload gives
+// it. Tests set transcriptionRejection to exercise that path.
+const transcribeMock = sinon.spy(async () => {
+  if (transcriptionRejection) {
+    throw transcriptionRejection
+  }
+  return transcriptionResult
+})
 
 let answerFromGetAnswer = 'You book time off in the HR tool.'
 let transcriptionResult = ''
+let transcriptionRejection = null
 
 class AppMock {
   event(eventName, handler) {
@@ -139,6 +148,7 @@ beforeEach(() => {
   transcribeMock.resetHistory()
   answerFromGetAnswer = 'You book time off in the HR tool.'
   transcriptionResult = ''
+  transcriptionRejection = null
 })
 
 describe('the message handler', () => {
@@ -309,6 +319,54 @@ describe('the message handler', () => {
     t.assert.ok(
       postedMessages(client).includes(answerFromGetAnswer),
       'the answer should be posted'
+    )
+  })
+
+  // A user attaches a PDF or a screenshot and types the question alongside it.
+  // Whisper rejects the non-audio body, which is a failure of the file, not of
+  // the question sitting in event.text.
+  test('falls back to the text alongside a file when the transcription fails', async t => {
+    transcriptionRejection = new Error('Whisper rejected the uploaded file')
+    const client = createClientMock()
+
+    await messageHandler({
+      event: { ...voiceNoteEvent, text: 'How do I book time off?' },
+      client
+    })
+
+    sinon.assert.calledOnce(transcribeMock)
+    sinon.assert.calledOnce(getAnswerMock)
+    t.assert.strictEqual(
+      getAnswerMock.firstCall.args[0].question,
+      'How do I book time off?'
+    )
+
+    const posted = postedMessages(client)
+    t.assert.ok(
+      posted.includes(answerFromGetAnswer),
+      `the answer should be posted, got ${JSON.stringify(posted)}`
+    )
+    t.assert.ok(
+      !posted.includes(genericErrorResponse),
+      'the typed question is answerable, so nothing has gone wrong'
+    )
+  })
+
+  // The boundary of the fallback above: with nothing typed there is no question
+  // to fall back on, so a failed transcription stays an internal failure.
+  test('reports the generic error when the transcription fails and nothing was typed', async t => {
+    transcriptionRejection = new Error('Whisper rejected the uploaded file')
+    const client = createClientMock()
+
+    await messageHandler({ event: voiceNoteEvent, client })
+
+    sinon.assert.calledOnce(transcribeMock)
+    sinon.assert.notCalled(getAnswerMock)
+
+    const posted = postedMessages(client)
+    t.assert.ok(
+      posted.includes(genericErrorResponse),
+      `the generic error should be posted, got ${JSON.stringify(posted)}`
     )
   })
 })

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -184,7 +184,9 @@ describe('the message handler', () => {
   })
 
   test('transcribes a voice note and answers what was said', async t => {
-    transcriptionResult = 'How do I book time off?'
+    // Whisper's text format newline-terminates what it returns, so the value
+    // reaching getAnswer has to be the trimmed one.
+    transcriptionResult = 'How do I book time off?\n'
     const client = createClientMock()
 
     await messageHandler({ event: voiceNoteEvent, client })
@@ -196,14 +198,19 @@ describe('the message handler', () => {
     )
 
     sinon.assert.calledOnce(getAnswerMock)
+    const askedQuestion = getAnswerMock.firstCall.args[0].question
+    t.assert.strictEqual(askedQuestion, 'How do I book time off?')
     t.assert.strictEqual(
-      getAnswerMock.firstCall.args[0].question,
-      transcriptionResult
+      askedQuestion,
+      askedQuestion.trim(),
+      'no trailing whitespace should reach getAnswer'
     )
 
     const posted = postedMessages(client)
     t.assert.ok(
-      posted.some(text => text.includes(transcriptionResult)),
+      posted.some(text =>
+        text.includes('You asked: "How do I book time off?"')
+      ),
       'the acknowledgement should quote what was heard'
     )
     t.assert.ok(
@@ -234,6 +241,55 @@ describe('the message handler', () => {
     // Nothing to ask, so nothing is asked. getAnswer now throws on a missing
     // question, which is what produced the generic error.
     sinon.assert.notCalled(getAnswerMock)
+  })
+
+  // Whisper with response_format: 'text' returns a plain string, and returns
+  // only whitespace for audio that contains no speech. A whitespace-only string
+  // is truthy, so branching on the untrimmed value took the "we heard
+  // something" path with nothing in it.
+  test('treats a whitespace-only transcription as no words heard', async t => {
+    transcriptionResult = ' \n '
+    const client = createClientMock()
+
+    await messageHandler({ event: voiceNoteEvent, client })
+
+    const posted = postedMessages(client)
+    t.assert.strictEqual(
+      posted.length,
+      1,
+      `exactly one message should be posted, got ${JSON.stringify(posted)}`
+    )
+    t.assert.match(posted[0], /could not make out any words in that recording/i)
+    t.assert.ok(
+      !posted.includes(genericErrorResponse),
+      'whitespace from the transcriber is not an internal failure'
+    )
+
+    sinon.assert.notCalled(getAnswerMock)
+  })
+
+  test('keeps the typed question when the transcription is only whitespace', async t => {
+    transcriptionResult = ' \n '
+    const client = createClientMock()
+
+    await messageHandler({
+      event: { ...voiceNoteEvent, text: 'How do I book time off?' },
+      client
+    })
+
+    sinon.assert.calledOnce(getAnswerMock)
+    t.assert.strictEqual(
+      getAnswerMock.firstCall.args[0].question,
+      'How do I book time off?'
+    )
+    t.assert.ok(
+      postedMessages(client).includes(answerFromGetAnswer),
+      'the answer should be posted'
+    )
+    t.assert.ok(
+      !postedMessages(client).includes(genericErrorResponse),
+      'the typed question is answerable, so nothing has gone wrong'
+    )
   })
 
   test('falls back to the text alongside a file when the audio yields nothing', async t => {

--- a/packages/slack-bot/test/messageHandler.test.js
+++ b/packages/slack-bot/test/messageHandler.test.js
@@ -147,6 +147,17 @@ const otherBotMessageEvent = {
   ts: '1700000000.000400'
 }
 
+// The notice Slack sends when someone pins a message in the conversation.
+const pinnedItemNoticeEvent = {
+  type: 'message',
+  subtype: 'pinned_item',
+  user: 'U0000000000',
+  text: '<@U0000000000> pinned a message to this conversation.',
+  channel: 'D0000000000',
+  channel_type: 'im',
+  ts: '1700000000.000600'
+}
+
 // The subtype deny list is deliberately not an allow list, so a subtype we do
 // not recognise is let through to be answered. This one carries neither text
 // nor a file, which leaves nothing to answer and nobody waiting on a reply.
@@ -203,6 +214,20 @@ describe('the message handler', () => {
     const client = createClientMock()
 
     await messageHandler({ event: otherBotMessageEvent, client })
+
+    sinon.assert.notCalled(getAnswerMock)
+    sinon.assert.notCalled(client.reactions.add)
+    t.assert.deepStrictEqual(postedMessages(client), [])
+  })
+
+  // A person pinning one of the bot's answers in the DM. The notice carries a
+  // real user and real text, so without the subtype guard the bot reacted,
+  // acknowledged, and asked the model to answer "pinned a message to this
+  // conversation".
+  test('leaves no trace on the notice a pinned message produces', async t => {
+    const client = createClientMock()
+
+    await messageHandler({ event: pinnedItemNoticeEvent, client })
 
     sinon.assert.notCalled(getAnswerMock)
     sinon.assert.notCalled(client.reactions.add)

--- a/packages/slack-bot/test/transcribe.test.js
+++ b/packages/slack-bot/test/transcribe.test.js
@@ -83,20 +83,28 @@ async function removeIfPresent(filePath) {
   await fs.rm(filePath, { force: true })
 }
 
-// Where downloadAudio puts a Slack file, so a test can look for what it left.
-function downloadedAudioPath(fileId) {
-  return path.join(os.tmpdir(), `${fileId}.mp4`)
+// Every scratch file downloadAudio could have written for one Slack file id.
+// The name carries a per-invocation suffix, so a test asking whether anything
+// was left behind has to look for the whole family rather than one fixed path.
+async function leftoverAudioFiles(fileId) {
+  const entries = await fs.readdir(os.tmpdir())
+  return entries.filter(
+    entry => entry.startsWith(`${fileId}`) && entry.endsWith('.mp4')
+  )
 }
 
-async function downloadedAudioExists(fileId) {
-  return fs
-    .access(downloadedAudioPath(fileId))
-    .then(() => true)
-    .catch(() => false)
+async function removeLeftoverAudioFiles(fileId) {
+  const leftovers = await leftoverAudioFiles(fileId)
+  await Promise.all(
+    leftovers.map(entry => removeIfPresent(path.join(os.tmpdir(), entry)))
+  )
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   respondToDownload = respondWithAudio
+  // The temporary directory outlives the test run, so a file an earlier run
+  // leaked would otherwise be read as this run's leak.
+  await removeLeftoverAudioFiles(audioFile.id)
 })
 
 describe('downloadAudio', () => {
@@ -152,6 +160,74 @@ describe('downloadAudio', () => {
       downloadAudio(audioFile.url_private_download, audioFile.id),
       responseError
     )
+  })
+
+  test('leaves nothing behind when the response fails part way through', async t => {
+    // Slack's response aborting mid-download: ECONNRESET, a TLS reset, or the
+    // platform cutting the connection. Rejecting was all that happened, and
+    // pipe does not tear the destination down when the source fails, so the
+    // partial file stayed on disk with its write handle still open. transcribe
+    // cannot clean up after this one: downloadAudio throws before it ever
+    // returns a path, so the caller's finally is never reached.
+    const responseError = new Error('aborted')
+    respondToDownload = (request, onResponse) => {
+      const response = new PassThrough()
+      response.statusCode = 200
+      onResponse(response)
+      // Bytes reach the write stream before the failure, which is what makes
+      // this a leak rather than an empty file that was never opened.
+      response.write('the first half of a voice note')
+      setImmediate(() => response.destroy(responseError))
+    }
+
+    await t.assert.rejects(
+      downloadAudio(audioFile.url_private_download, audioFile.id)
+    )
+
+    t.assert.deepStrictEqual(
+      await leftoverAudioFiles(audioFile.id),
+      [],
+      'a download that failed mid-stream should leave no partial file behind'
+    )
+  })
+
+  test('gives each download its own scratch file', async t => {
+    // Slack redelivers an event it has not seen a 200 for, so two runs for the
+    // same voice note can overlap. Sharing one destination had them writing
+    // over each other, and now that each run removes the file when it is done
+    // the first to finish would delete the other's download.
+    const [first, second] = await Promise.all([
+      downloadAudio(audioFile.url_private_download, audioFile.id),
+      downloadAudio(audioFile.url_private_download, audioFile.id)
+    ])
+
+    try {
+      t.assert.notStrictEqual(
+        first,
+        second,
+        'two concurrent downloads of one file must not share a destination'
+      )
+    } finally {
+      await removeIfPresent(first)
+      await removeIfPresent(second)
+    }
+  })
+
+  test('keeps the query string and port the download URL carries', async t => {
+    // url_private_download is a signed URL: dropping its query string asks
+    // Slack for a path that does not exist, and dropping the port sends the
+    // request somewhere else entirely.
+    const signedUrl =
+      'https://files.slack.com:8443/files-pri/T0-F0/download/audio.webm?t=xoxe-1-abc&d=1'
+
+    await removeIfPresent(await downloadAudio(signedUrl, audioFile.id))
+
+    const [options] = httpsGetMock.lastCall.args
+    t.assert.strictEqual(
+      options.path,
+      '/files-pri/T0-F0/download/audio.webm?t=xoxe-1-abc&d=1'
+    )
+    t.assert.strictEqual(options.port, '8443')
   })
 
   test('rejects when the downloaded file cannot be written', async t => {
@@ -257,9 +333,9 @@ describe('transcribe', () => {
 
     await transcribe(audioFile, openai)
 
-    t.assert.strictEqual(
-      await downloadedAudioExists(audioFile.id),
-      false,
+    t.assert.deepStrictEqual(
+      await leftoverAudioFiles(audioFile.id),
+      [],
       'the downloaded audio should not outlive the transcription'
     )
   })
@@ -275,17 +351,19 @@ describe('transcribe', () => {
 
     await t.assert.rejects(transcribe(audioFile, openai), whisperRejection)
 
-    t.assert.strictEqual(
-      await downloadedAudioExists(audioFile.id),
-      false,
+    t.assert.deepStrictEqual(
+      await leftoverAudioFiles(audioFile.id),
+      [],
       'a failed transcription should not leave its download behind'
     )
   })
 
   test('tolerates the downloaded audio already being gone', async t => {
     const openai = createOpenaiMock(spokenQuestion)
-    openai.audio.transcriptions.create = sinon.spy(async () => {
-      await removeIfPresent(downloadedAudioPath(audioFile.id))
+    openai.audio.transcriptions.create = sinon.spy(async request => {
+      // The read stream knows where the download went, which is the only way
+      // to find it now that the name carries a per-invocation suffix.
+      await removeIfPresent(request.file.path)
       return spokenQuestion
     })
 

--- a/packages/slack-bot/test/transcribe.test.js
+++ b/packages/slack-bot/test/transcribe.test.js
@@ -1,25 +1,52 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
+import { EventEmitter } from 'node:events'
 import { PassThrough } from 'node:stream'
-import { after, before, describe, test, mock } from 'node:test'
+import { beforeEach, describe, test, mock } from 'node:test'
 import sinon from 'sinon'
 
 // transcribe downloads the audio over HTTPS before handing it to OpenAI, so
 // node:https is the one thing that has to be faked. Writing and reading the
-// downloaded file stay real, into a temporary directory. mock.module registers
-// a specifier once per process, which is why this lives in a test file of its
-// own.
-const httpsGetMock = sinon.spy((options, onResponse) => {
+// downloaded file stay real, under the system temporary directory the download
+// writes to. mock.module registers a specifier once per process, which is why
+// this lives in a test file of its own.
+
+function respondWithAudio(
+  request,
+  onResponse,
+  { statusCode = 200, body = 'fake audio bytes' } = {}
+) {
   const response = new PassThrough()
+  response.statusCode = statusCode
   onResponse(response)
-  response.end('fake audio bytes')
+  response.end(body)
   return response
+}
+
+// What the faked https.get does once the caller has had its request object
+// back, set per test. The default serves the audio successfully.
+let respondToDownload = respondWithAudio
+
+const httpsGetMock = sinon.spy((options, onResponse) => {
+  const request = new EventEmitter()
+  // ClientRequest.destroy(error) surfaces the error to the request's own
+  // 'error' listeners, which is how a timeout becomes a rejection.
+  request.destroy = sinon.spy(error => {
+    if (error) {
+      request.emit('error', error)
+    }
+  })
+  // The real https.get returns the request before any response arrives, so a
+  // listener registered after the call still sees the outcome.
+  setImmediate(() => respondToDownload(request, onResponse))
+  return request
 })
 
 mock.module('node:https', { defaultExport: { get: httpsGetMock } })
 
-const { transcribe, transcriptionText } = await import('../src/utils.js')
+const { downloadAudio, transcribe, transcriptionText } =
+  await import('../src/utils.js')
 
 const audioFile = {
   id: 'F0000000000',
@@ -52,21 +79,119 @@ function createOpenaiMock(transcriptionResponse) {
   }
 }
 
-let previousWorkingDirectory
-let downloadDirectory
+async function removeIfPresent(filePath) {
+  await fs.rm(filePath, { force: true })
+}
 
-before(async () => {
-  // downloadAudio writes ./<file id>.mp4 relative to the working directory.
-  previousWorkingDirectory = process.cwd()
-  downloadDirectory = await fs.mkdtemp(
-    path.join(os.tmpdir(), 'slack-bot-transcribe-')
-  )
-  process.chdir(downloadDirectory)
+beforeEach(() => {
+  respondToDownload = respondWithAudio
 })
 
-after(async () => {
-  process.chdir(previousWorkingDirectory)
-  await fs.rm(downloadDirectory, { recursive: true, force: true })
+describe('downloadAudio', () => {
+  test('writes the audio under the system temporary directory', async t => {
+    // The working directory of a Cloud Run instance is an in-memory
+    // filesystem charged against the instance memory limit, and a scratch
+    // file belongs in the temporary directory rather than beside the source.
+    const downloadedPath = await downloadAudio(
+      audioFile.url_private_download,
+      audioFile.id
+    )
+
+    try {
+      t.assert.strictEqual(
+        path.dirname(downloadedPath),
+        os.tmpdir(),
+        'the download should not land in the working directory'
+      )
+      t.assert.strictEqual(
+        await fs.readFile(downloadedPath, 'utf8'),
+        'fake audio bytes'
+      )
+    } finally {
+      await removeIfPresent(downloadedPath)
+    }
+  })
+
+  test('rejects when the request itself fails', async t => {
+    // files.slack.com unreachable: ENOTFOUND, ECONNRESET or a TLS failure. The
+    // ClientRequest emits 'error', and with no listener for it that was an
+    // uncaught exception which took the whole instance down.
+    const connectionError = new Error('getaddrinfo ENOTFOUND files.slack.com')
+    respondToDownload = request => {
+      request.emit('error', connectionError)
+    }
+
+    await t.assert.rejects(
+      downloadAudio(audioFile.url_private_download, audioFile.id),
+      connectionError
+    )
+  })
+
+  test('rejects when the response fails part way through', async t => {
+    const responseError = new Error('aborted')
+    respondToDownload = (request, onResponse) => {
+      const response = new PassThrough()
+      response.statusCode = 200
+      onResponse(response)
+      response.emit('error', responseError)
+    }
+
+    await t.assert.rejects(
+      downloadAudio(audioFile.url_private_download, audioFile.id),
+      responseError
+    )
+  })
+
+  test('rejects when the downloaded file cannot be written', async t => {
+    // The write stream error, which nothing listened for either.
+    await t.assert.rejects(
+      downloadAudio(
+        audioFile.url_private_download,
+        path.join('a-directory-that-does-not-exist', 'F0000000000')
+      ),
+      { code: 'ENOENT' }
+    )
+  })
+
+  test('rejects when a stalled response times out', async t => {
+    // Slack accepts the connection and then sends nothing. With no timeout the
+    // promise never settled and the handler waited on it forever.
+    respondToDownload = request => {
+      request.emit('timeout')
+    }
+
+    await t.assert.rejects(
+      downloadAudio(audioFile.url_private_download, audioFile.id),
+      /timed out/i
+    )
+    sinon.assert.called(httpsGetMock.lastCall.returnValue.destroy)
+  })
+
+  test('asks for a request timeout, without which the timeout never fires', async t => {
+    await removeIfPresent(
+      await downloadAudio(audioFile.url_private_download, audioFile.id)
+    )
+
+    const [options] = httpsGetMock.lastCall.args
+    t.assert.strictEqual(typeof options.timeout, 'number')
+    t.assert.ok(options.timeout > 0, 'the timeout has to be a real deadline')
+  })
+
+  test('rejects a non-2xx response rather than writing the error body to disk', async t => {
+    // An expired or forbidden Slack download URL answers with an error body,
+    // which was written to disk and handed to Whisper as though it were audio.
+    respondToDownload = (request, onResponse) => {
+      respondWithAudio(request, onResponse, {
+        statusCode: 403,
+        body: 'expired signature'
+      })
+    }
+
+    await t.assert.rejects(
+      downloadAudio(audioFile.url_private_download, audioFile.id),
+      /403/
+    )
+  })
 })
 
 describe('transcribe', () => {

--- a/packages/slack-bot/test/transcribe.test.js
+++ b/packages/slack-bot/test/transcribe.test.js
@@ -302,6 +302,23 @@ describe('transcriptionText', () => {
     t.assert.strictEqual(transcriptionText(''), '')
   })
 
+  // What Whisper actually returns for audio with no speech in it, and the
+  // reason the documented "empty string if the audio yielded no words" was
+  // false: a whitespace-only string is truthy, so every caller had to trim
+  // again to find out whether any words were heard.
+  test('returns the empty string for a whitespace-only transcription', t => {
+    t.assert.strictEqual(transcriptionText('\n'), '')
+    t.assert.strictEqual(transcriptionText('   '), '')
+    t.assert.strictEqual(transcriptionText({ text: '\n' }), '')
+  })
+
+  test('trims the newline Whisper terminates its text with', t => {
+    t.assert.strictEqual(
+      transcriptionText(`${spokenQuestion}\n`),
+      spokenQuestion
+    )
+  })
+
   test('reads text off an object response', t => {
     t.assert.strictEqual(
       transcriptionText({ text: spokenQuestion }),

--- a/packages/slack-bot/test/transcribe.test.js
+++ b/packages/slack-bot/test/transcribe.test.js
@@ -83,6 +83,18 @@ async function removeIfPresent(filePath) {
   await fs.rm(filePath, { force: true })
 }
 
+// Where downloadAudio puts a Slack file, so a test can look for what it left.
+function downloadedAudioPath(fileId) {
+  return path.join(os.tmpdir(), `${fileId}.mp4`)
+}
+
+async function downloadedAudioExists(fileId) {
+  return fs
+    .access(downloadedAudioPath(fileId))
+    .then(() => true)
+    .catch(() => false)
+}
+
 beforeEach(() => {
   respondToDownload = respondWithAudio
 })
@@ -234,6 +246,50 @@ describe('transcribe', () => {
       'string',
       'callers treat the result as text, so the type must not vary'
     )
+  })
+
+  // The service runs with --min-instances=1 on a 512MB Cloud Run instance, so
+  // an instance lives indefinitely and the files it writes are held in its
+  // memory. One file left behind per upload grows until the instance is
+  // OOM-killed mid-request.
+  test('removes the downloaded audio once the transcription has been read', async t => {
+    const openai = createOpenaiMock(spokenQuestion)
+
+    await transcribe(audioFile, openai)
+
+    t.assert.strictEqual(
+      await downloadedAudioExists(audioFile.id),
+      false,
+      'the downloaded audio should not outlive the transcription'
+    )
+  })
+
+  test('removes the downloaded audio when the transcription throws', async t => {
+    // Whisper rejects a body that is not audio, which is what a PDF or a
+    // screenshot upload gives it. That path leaked its bytes too.
+    const openai = createOpenaiMock(spokenQuestion)
+    const whisperRejection = new Error('Whisper rejected the uploaded file')
+    openai.audio.transcriptions.create = sinon.spy(async () => {
+      throw whisperRejection
+    })
+
+    await t.assert.rejects(transcribe(audioFile, openai), whisperRejection)
+
+    t.assert.strictEqual(
+      await downloadedAudioExists(audioFile.id),
+      false,
+      'a failed transcription should not leave its download behind'
+    )
+  })
+
+  test('tolerates the downloaded audio already being gone', async t => {
+    const openai = createOpenaiMock(spokenQuestion)
+    openai.audio.transcriptions.create = sinon.spy(async () => {
+      await removeIfPresent(downloadedAudioPath(audioFile.id))
+      return spokenQuestion
+    })
+
+    t.assert.strictEqual(await transcribe(audioFile, openai), spokenQuestion)
   })
 })
 

--- a/packages/slack-bot/test/transcribe.test.js
+++ b/packages/slack-bot/test/transcribe.test.js
@@ -1,0 +1,140 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { PassThrough } from 'node:stream'
+import { after, before, describe, test, mock } from 'node:test'
+import sinon from 'sinon'
+
+// transcribe downloads the audio over HTTPS before handing it to OpenAI, so
+// node:https is the one thing that has to be faked. Writing and reading the
+// downloaded file stay real, into a temporary directory. mock.module registers
+// a specifier once per process, which is why this lives in a test file of its
+// own.
+const httpsGetMock = sinon.spy((options, onResponse) => {
+  const response = new PassThrough()
+  onResponse(response)
+  response.end('fake audio bytes')
+  return response
+})
+
+mock.module('node:https', { defaultExport: { get: httpsGetMock } })
+
+const { transcribe, transcriptionText } = await import('../src/utils.js')
+
+const audioFile = {
+  id: 'F0000000000',
+  url_private_download:
+    'https://files.slack.com/files-pri/T0000000000-F0000000000/download/audio_message.webm'
+}
+
+const spokenQuestion = 'How do I book time off?'
+
+function createOpenaiMock(transcriptionResponse) {
+  // Collects what was actually uploaded, so the download half of transcribe is
+  // exercised rather than assumed.
+  const uploadedAudio = []
+
+  return {
+    uploadedAudio,
+    audio: {
+      transcriptions: {
+        create: sinon.spy(async request => {
+          // The real SDK reads the file stream to send it. Reading it here too
+          // keeps the download honest and leaves nothing open when the test
+          // ends.
+          for await (const chunk of request.file) {
+            uploadedAudio.push(chunk)
+          }
+          return transcriptionResponse
+        })
+      }
+    }
+  }
+}
+
+let previousWorkingDirectory
+let downloadDirectory
+
+before(async () => {
+  // downloadAudio writes ./<file id>.mp4 relative to the working directory.
+  previousWorkingDirectory = process.cwd()
+  downloadDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'slack-bot-transcribe-')
+  )
+  process.chdir(downloadDirectory)
+})
+
+after(async () => {
+  process.chdir(previousWorkingDirectory)
+  await fs.rm(downloadDirectory, { recursive: true, force: true })
+})
+
+describe('transcribe', () => {
+  test('returns the transcription when the SDK resolves to a plain string', async t => {
+    // What response_format: 'text' actually resolves to. Reading .text off it
+    // returned undefined, and every voice note answered the old default
+    // question instead of what the person said.
+    const openai = createOpenaiMock(spokenQuestion)
+
+    const result = await transcribe(audioFile, openai)
+
+    t.assert.strictEqual(result, spokenQuestion)
+
+    sinon.assert.calledOnce(openai.audio.transcriptions.create)
+    const [request] = openai.audio.transcriptions.create.firstCall.args
+    t.assert.strictEqual(request.model, 'whisper-1')
+    t.assert.strictEqual(request.response_format, 'text')
+    t.assert.strictEqual(
+      Buffer.concat(openai.uploadedAudio).toString(),
+      'fake audio bytes',
+      'the audio Slack served should reach OpenAI'
+    )
+  })
+
+  test('returns the transcription when the SDK resolves to an object carrying text', async t => {
+    // The shape a different response_format, or a future SDK, returns.
+    const openai = createOpenaiMock({ text: spokenQuestion })
+
+    t.assert.strictEqual(await transcribe(audioFile, openai), spokenQuestion)
+  })
+
+  test('returns an empty string, never undefined, for an unusable response', async t => {
+    const openai = createOpenaiMock(undefined)
+
+    const result = await transcribe(audioFile, openai)
+
+    t.assert.strictEqual(result, '')
+    t.assert.strictEqual(
+      typeof result,
+      'string',
+      'callers treat the result as text, so the type must not vary'
+    )
+  })
+})
+
+describe('transcriptionText', () => {
+  test('returns a plain string response unchanged', t => {
+    t.assert.strictEqual(transcriptionText(spokenQuestion), spokenQuestion)
+  })
+
+  test('returns the empty string a silent recording transcribes to', t => {
+    t.assert.strictEqual(transcriptionText(''), '')
+  })
+
+  test('reads text off an object response', t => {
+    t.assert.strictEqual(
+      transcriptionText({ text: spokenQuestion }),
+      spokenQuestion
+    )
+  })
+
+  test('returns an empty string for an object with no usable text', t => {
+    t.assert.strictEqual(transcriptionText({ segments: [] }), '')
+    t.assert.strictEqual(transcriptionText({ text: 42 }), '')
+  })
+
+  test('returns an empty string for a missing response', t => {
+    t.assert.strictEqual(transcriptionText(undefined), '')
+    t.assert.strictEqual(transcriptionText(null), '')
+  })
+})


### PR DESCRIPTION
Fixes #983

## Cause

When the bot's answer contains a URL, Slack unfurls the link and sends the bot's own
message back as a `message` event with the `message_changed` subtype. The handler in
`packages/slack-bot/src/bot.js` filtered a single subtype:

```js
if (event.subtype && event.subtype === 'bot_message') {
  return
}
```

`message_changed` is not `bot_message`, so the unfurl was processed as though a person had
asked something. On that event shape the text lives at `event.message.text`, not
`event.text`, so `questionInput` was `undefined` and the default parameter in `getAnswer`,
`question = 'What is NearForm?'`, took over. The bot posted a second acknowledgement and a
confident answer to a question nobody asked, spent an embedding request and a chat
completion doing it, and added a reaction to its own message.

The filter also closes a latent loop. The trigger is the bot's own answer containing a
link, so an answer that itself contained a link would unfurl and trigger another round.
The occurrence in the logs terminated only because the default answer happens to contain
no URL.

## Changes

1. **Ignore the message events that are not a person speaking** (`messageEvents.js`,
   `bot.js`). The `bot_message`-only guard is replaced by `isPlainUserMessage`, which
   rejects a deny list of non-user subtypes, plus any event carrying a `bot_id` or
   `hidden`. Both new guards sit ahead of the reaction and the acknowledgement, so an event
   we should not answer leaves no trace.

2. **Do nothing when there is no question** (`bot.js`). If the event carries neither text
   nor a file to transcribe, the handler returns without posting anything. There is
   deliberately no user-facing message for this case: it is not a user-visible situation,
   it is an event we should not have been sent.

3. **`getAnswer` requires a question** (`getAnswer.js`). The
   `question = 'What is NearForm?'` default is gone; a missing, blank or non-string
   question throws `getAnswer requires a question` before any OpenAI call. That default is
   what converted a spurious event into a plausible answer rather than an obvious failure.

4. **`transcribe` returns the transcription** (`utils.js`). It never has: with
   `response_format: 'text'` the SDK resolves to a plain string, so reading `.text` off it
   gave `undefined`. See below.

5. **A recording with no words gets an honest message** (`bot.js`), not the generic error.
   "No words" means no words after trimming: see the review-fix note below.

6. **A failed transcription does not discard a typed question** (`bot.js`). Added in the
   second review fix below: the `catch` around `transcribe` sets `processingError` only
   when there is nothing typed to fall back on.

The decisions in points 1 and 2 live in `packages/slack-bot/src/messageEvents.js` as pure
predicates (`isPlainUserMessage`, `hasQuestionText`, `hasFileAttachment`,
`carriesQuestion`), so they are testable without constructing a Bolt app.

Retrieval, the prompt, the embeddings and the deploy workflows are untouched.
`unfurl_links: false` on the outgoing messages would also have stopped the unfurl, and was
deliberately not used: the event filter is the correct fix and suppressing unfurls changes
what users see.

## History of this PR, plainly

Two things are worth stating rather than tidying away.

**The first version of this PR would have disabled file and voice handling.** Its guard
was `!event.subtype && !event.bot_id && !event.hidden`, which rejects the presence of any
subtype at all. Slack delivers a person's file upload, a voice note in a DM included, as a
`message` event with `subtype: 'file_share'` and the file in `event.files`. That is exactly
what the transcription branch in the handler and the `files:read` scope in
`slack_manifest.yaml` exist for, so the guard would have silently switched off a supported
feature. `thread_broadcast` and `me_message` are likewise people talking.

**`transcribe` was already broken before this PR, and this PR would have kept it broken.**
It returned `undefined` for every recording. Nobody noticed because the old `question`
default absorbed it: every voice note answered "What is NearForm?". Removing that default
in point 3 turns a silent wrong answer into a thrown error, so leaving `transcribe` alone
would have restored a feature that could not work.

## The deny list, and why it is a deny list

`nonUserMessageSubtypes` in `messageEvents.js` holds 20 subtypes, in two groups:

- Not a message anyone typed: `bot_message`, `message_changed`, `message_deleted`,
  `message_replied`, `tombstone`, `ekm_access_denied`.
- Channel membership and channel metadata notices, whose text reads like "so-and-so joined
  the channel" or "set the channel topic" and which the model would answer as a question:
  `channel_join`, `channel_leave`, `channel_topic`, `channel_purpose`, `channel_name`,
  `channel_archive`, `channel_unarchive`, `group_join`, `group_leave`, `group_topic`,
  `group_purpose`, `group_name`, `group_archive`, `group_unarchive`.

Absent on purpose, so they are answered: `file_share`, `thread_broadcast`, `me_message`.

A deny list rather than an allow list, deliberately. We are not confident we know every
subtype string Slack may send, and an unrecognised one is far better answered, which is
what the bot did before this guard existed, than silently dropped: a surprising answer is
visible, no answer at all looks like the bot is broken. There is a test for that property.

The `message_changed` unfurl from #983 is still rejected, by the deny list and by the
`hidden` check independently. The `bot_id` in the event as logged in the issue appears to
be nested under `message`, so the top-level `bot_id` check is not claimed as a third
ground here.

Today only `message.im` is subscribed in `slack_manifest.yaml`, so the channel subtypes
should not arrive at all. They are listed because a future subscription is a config change,
not a code change, and this is the file that decides.

## Tests

67 tests in the slack-bot workspace, 12 suites.

- `test/messageEvents.test.js`, 22 tests. The `message_changed` fixture is the trimmed
  event from the issue, including its nested `message.text`. New: every deny-list entry is
  asserted rejected, `file_share`, `thread_broadcast` and `me_message` are asserted
  accepted, an unrecognised subtype is asserted accepted, and a realistic `file_share`
  voice note carrying `files` and an empty `text` is asserted both a plain user message and
  a carrier of a question.
- `test/transcribe.test.js`, 8 tests. New. `transcribe` for both response shapes, a plain
  string and an object carrying `text`, plus an unusable response giving `''` rather than
  `undefined`, and `transcriptionText` directly for the edge shapes. `node:https` is the
  only thing faked: the download writes and reads a real file in a temporary directory, and
  the OpenAI mock reads the stream, so the test also asserts the bytes Slack served reach
  OpenAI.
- `test/messageHandler.test.js`, 12 tests. New. `@slack/bolt`, `openai`, `getAnswer.js` and
  `utils.js` are mocked so the registered listener itself can be exercised. It covers a
  typed question, the unfurl leaving no trace, another bot's message being ignored, a voice
  note transcribed and answered, a wordless recording getting the honest message and not
  the generic error, and typed text alongside a file being used when the audio yields
  nothing. The `getAnswer` mock throws on a blank question exactly as the real one does,
  otherwise the handler would look fine here and post the generic error in production. Two
  of the cases came from the first review fix below, a whitespace-only transcription with
  no typed text and one alongside a typed question, and two from the second, a rejecting
  transcription alongside a typed question and the same rejection with nothing typed.
  One came from the fourth review cycle: the `carriesQuestion` guard in point 2, which
  until then was covered only as a pure predicate in `messageEvents.test.js` and not
  through the handler, is now exercised by a message event that passes
  `isPlainUserMessage` but carries neither text nor files. It uses an unrecognised
  subtype, which is the case the deny list deliberately admits, and asserts no reaction,
  no posted message and no `getAnswer` call.
- `test/getAnswerQuestionRequired.test.js`, 6 tests. Five rejection cases, each also
  asserting neither `embeddings.create` nor `chat.completions.create` was called, plus a
  positive control.

Each change was confirmed red first. The three new accept cases in `messageEvents.test.js`
failed against the blanket-subtype guard; 7 of 8 in `transcribe.test.js` failed before the
return was fixed, the one pass being the object shape the old `.text` read happened to
handle; and the wordless-recording test failed with the actual defect, the posted message
being `'It appears I have run into an issue looking up an answer for you. Please try
again'`.

**Mutation testing.** 32 mutations were applied one at a time to the source and the suite
re-run, at the head before the two review fixes below: one per clause of `isPlainUserMessage`, including restoring the blanket subtype
rejection; one per deny-list entry, each removed in turn; four on the transcription shape
handling, including restoring the old `.text` read; and three on the handler. All 32 were
caught. One survived on the first pass: deleting the `isPlainUserMessage` guard from the
handler changed nothing, because the unfurl event has no top-level `text` and the
`carriesQuestion` guard stopped it anyway. The test named for that guard therefore did not
discriminate, so a bot message that does carry top-level text was added, and the mutation
is now caught.

A later review cycle ran the mirror-image mutation and found a second survivor: deleting
the `carriesQuestion` guard from the handler left all 11 handler tests green, because every
fixture that reached it carried text or files. The test described in the list above closes
that, and deleting the guard now fails it on the `getAnswer` assertion, the question
arriving as `undefined`.

## Verification

- `npm run lint` at the root: exit 0, no findings.
- `npm test` at the root: exit 0. crawler 4/4, embeddings-creation 1/1, slack-bot 67/67.
- CI's own per-workspace legs, `npm run lint --workspace=X` then `npm test --workspace=X`
  for crawler, slack-bot and embeddings-creation: all exit 0.
- The slack-bot workspace suite run 30 consecutive times on head `7b94f0f`: 30/30, 67
  passing and 0 failing every run.

## Review fix 1: a whitespace-only transcription

Raised in review, reproduced, and fixed in `0b5e6ac`.

Whisper with `response_format: 'text'` returns a plain string, typically newline
terminated, and returns only whitespace for audio containing no speech. The
file-attachment branch trimmed that value for display but branched on the untrimmed one,
and a whitespace-only string is truthy. So a wordless voice note took the "we heard
something" path: it skipped the unintelligible-audio message in point 5 above, set the
question to whitespace, and where the user had typed a question alongside the file it
overwrote that question too. `getAnswer` then threw on the blank question, per point 3,
and the outer catch posted the generic error, which is the failure this PR set out to
replace.

The fix trims once and decides on the trimmed value, which also stops a trailing newline
reaching `getAnswer` on the happy path. The deny list, `transcriptionText`, retrieval, the
prompt and the workflows are untouched.

Reproduced red at `9af5c00` in both sub-cases, each posting `You asked: ""` followed by the
generic error: a voice note with no typed text, and a voice note carrying
`text: 'How do I book time off?'` where the typed question was answerable and was lost. Two
tests were added for those, plus an assertion on the existing happy-path case that the
value reaching `getAnswer` carries no trailing whitespace. All three failed before the fix
and pass after it; the existing empty-string cases were unchanged and still pass.

## Review fix 2: a failed transcription discarded a typed question

Raised in review, reproduced, and fixed in `86c10c1`.

The `catch` around `transcribe` set `processingError = true` unconditionally, so any
transcription failure sent the user the generic error. Whisper rejects a body that is not
audio, so a user who attached a PDF or a screenshot *and* typed "How do I book time off?"
alongside it got the generic error, and the answerable question sitting in `event.text` was
never used.

That was an asymmetry this PR had itself created the other half of. When transcription
returns nothing, review fix 1 above falls back to the typed text and only returns early
when nothing was typed. When transcription throws, there was no fallback. Same user
situation, opposite outcome.

The fix is one decision: `processingError = !hasQuestionText(event)`, so a failure with
typed text proceeds with the typed question and a failure with nothing typed still reports
the generic error. `transcriptionText`, the deny list, retrieval, the prompt and the
workflows are untouched, and no mimetype check was added.

Reproduced red at `0b5e6ac`: the new case asserting the typed question reaches `getAnswer`
failed with `expected spy to be called once but was called 0 times`, `getAnswer` never
having been reached. It passes after the fix. The companion case, a rejecting transcription
with nothing typed, is a positive control for the boundary: it asserts the generic error is
still posted and `getAnswer` still not called, and it passed both before and after, so the
fix demonstrably did not move that path.

## Worth a reviewer's attention

A person uploading a non-audio file, a PDF or an image, with no accompanying text still
goes to Whisper, which will fail, and they get the generic error message. That is a real
defect, and it predates this PR: `file_share` was accepted before the guard existed too, so
this is behaviour restored rather than introduced. It is not fixed here because it needs a
mimetype check and a message of its own, which is more than this fix's scope. Worth its own
issue.

Since review fix 2, a transcription failure produces the generic error only when the user
typed nothing alongside the file; with typed text the handler answers the typed question.
Neither case gets a message of its own explaining that the file could not be read, which is
part of the same mimetype-check issue as the paragraph above.



