### PR TITLE
fix: validate required environment variables at startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,10 +148,10 @@ a linked issue is red on arrival.
 `node:test` with `--experimental-test-module-mocks`, tests in each package's `test/`
 directory as `*.test.js`, fixtures in `test/mocks/`. Run with `npm test` (all workspaces)
 or `npm test --workspace=<name>`. As of 2026-09-10 the suite is green. The root script runs one
-`node:test` runner per workspace, reporting 10 in crawler, 7 in embeddings-creation and 116
+`node:test` runner per workspace, reporting 10 in crawler, 8 in embeddings-creation and 116
 in slack-bot (15 suites). Two of slack-bot's 116 are the test-less fixture modules under
-`test/mocks/`, which node's default glob executes as test files, so there are 131 real tests
-across 133 reported. The crawler's fixtures are `.json` and are not executed, so its 10 are
+`test/mocks/`, which node's default glob executes as test files, so there are 132 real tests
+across 134 reported. The crawler's fixtures are `.json` and are not executed, so its 10 are
 all real.
 
 Conventions: mock the network at the module boundary with `mock.module`, and use `sinon`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,11 +147,11 @@ a linked issue is red on arrival.
 
 `node:test` with `--experimental-test-module-mocks`, tests in each package's `test/`
 directory as `*.test.js`, fixtures in `test/mocks/`. Run with `npm test` (all workspaces)
-or `npm test --workspace=<name>`. As of 2026-09-09 the suite is green. The root script runs one
-`node:test` runner per workspace, reporting 4 in crawler, 1 in embeddings-creation and 105
-in slack-bot (14 suites). Two of slack-bot's 105 are the test-less fixture modules under
-`test/mocks/`, which node's default glob executes as test files, so there are 108 real tests
-across 110 reported. The crawler's fixtures are `.json` and are not executed, so its 4 are
+or `npm test --workspace=<name>`. As of 2026-09-10 the suite is green. The root script runs one
+`node:test` runner per workspace, reporting 10 in crawler, 7 in embeddings-creation and 116
+in slack-bot (15 suites). Two of slack-bot's 116 are the test-less fixture modules under
+`test/mocks/`, which node's default glob executes as test files, so there are 131 real tests
+across 133 reported. The crawler's fixtures are `.json` and are not executed, so its 10 are
 all real.
 
 Conventions: mock the network at the module boundary with `mock.module`, and use `sinon`
@@ -174,12 +174,20 @@ for spies and fakes. `embeddings-creation` needs `GCP_STORAGE_*` env vars, which
   data: they are git-ignored, keep them that way.
 - The GCS bucket is created with `--public-access-prevention` and uniform bucket-level
   access in `europe-west1`. Do not weaken either.
-- **No credential is validated before use.** `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`,
-  `OPENAI_API_KEY` and `NOTION_TOKEN` are read from `process.env` and passed straight to
-  constructors with no null or empty check, so a misconfigured deployment starts cleanly
-  and fails at the first request with an opaque client-library error instead of naming the
-  missing variable. `MAX_CONTEXT_TOKENS` is the only validated variable. If you add a new
-  required variable, validate it at startup rather than following the existing pattern.
+- **Required variables are validated at startup.** Each package has a `src/env.js`
+  exporting `validateEnv(env = process.env)`, called from its entry point
+  (`packages/*/src/index.js`, plus `packages/slack-bot/src/dev.js`) before anything else
+  is imported. It treats absent, empty and whitespace-only alike, collects every missing
+  name and throws one error listing all of them, and never puts a value in the message.
+  The clients are still built at module scope in `bot.js`, `create-embeddings.js` and
+  `notion.js`, so each entry point validates first and then `await import()`s the app
+  module: a static import would evaluate those constructors before the check ran.
+  Required sets follow `.github/workflows/deploy-step.yml`. For slack-bot,
+  `GCP_PROJECT_ID` and `GCP_EMBEDDING_SUBSCRIPTION` are required only when
+  `IS_LOCAL_ENVIRONMENT` is falsy, because they exist solely to name the Pub/Sub
+  subscription the local environment skips. `MAX_CONTEXT_TOKENS` is optional with a
+  default and is validated separately by `parsePositiveTokenCount`. If you add a new
+  required variable, add it to that package's `requiredEnvironmentVariables`.
 - Dependabot (`.github/dependabot.yml`) covers dependency updates; there is no SAST or
   secret-scanning step in CI and the repo has no SECURITY.md.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Add the following values in an `.env` file (needed for local development):
 | `GCP_STORAGE_BUCKET_NAME`       | GCP bucket name hosting embeddings file |
 | `GCP_STORAGE_SCRAPED_FILE_NAME` | Scraped data file name on the bucket    |
 
+All three are required. The crawler checks them before it starts, so a missing or empty
+value fails immediately with an error naming every variable that is missing, rather than
+part way through a crawl.
+
 ## Embeddings creation
 
 #### Environment variables
@@ -70,6 +74,10 @@ Add the following values in an `.env` file (needed for local development):
 | `OPENAI_API_KEY`                  | OpenAI API key                       |
 | `GCP_STORAGE_SCRAPED_FILE_NAME`   | Scraped data file name on the bucket |
 | `GCP_STORAGE_EMBEDDING_FILE_NAME` | Embeddings file name on the bucket   |
+
+All three are required. The function checks them as it starts, so a missing or empty value
+fails immediately with an error naming every variable that is missing. The bucket is not
+configured here: it comes from the event that triggers the function.
 
 ## Slack bot
 
@@ -90,6 +98,7 @@ Add the following values in an `.env` file (needed for local development):
 
 | Env var                           |                                                                            |
 | --------------------------------- | -------------------------------------------------------------------------- |
+| `GCP_PROJECT_ID`                  | GCP project id holding the Pub/Sub subscription                            |
 | `GCP_EMBEDDING_SUBSCRIPTION`      | Embedding file update subscription name                                    |
 | `GCP_STORAGE_BUCKET_NAME`         | GCP bucket name hosting embeddings file                                    |
 | `GCP_STORAGE_EMBEDDING_FILE_NAME` | Embeddings file name on the bucket                                         |
@@ -99,6 +108,13 @@ Add the following values in an `.env` file (needed for local development):
 | `MAX_CONTEXT_TOKENS`              | Optional. Token budget for the context sent to the model (default `4000`)  |
 
 The deploy workflow sets `MAX_CONTEXT_TOKENS` from its input of the same name, defaulting to 4000, and the repository variable of the same name overrides it.
+
+Every variable in the table except `MAX_CONTEXT_TOKENS` is required, and the bot checks
+them as it starts: a missing or empty value fails immediately with an error naming every
+variable that is missing, instead of surfacing later as an opaque error on the first Slack
+request. `GCP_PROJECT_ID` and `GCP_EMBEDDING_SUBSCRIPTION` are the exception when
+`IS_LOCAL_ENVIRONMENT` is set (as `make bot-start` sets it), since they are only used for
+the Pub/Sub subscription that a local run does not create.
 
 #### Slack setup
 

--- a/docs/crawler.md
+++ b/docs/crawler.md
@@ -29,6 +29,16 @@ bucket. It is the first stage of the pipeline and the only component that talks 
   500ms first (`packages/crawler/src/notion.js:69`, `:84`, `:116`).
 - Any failure in `crawl()` is logged and the process exits with code 1
   (`packages/crawler/src/crawl.js:17`).
+- The entry point validates the environment before anything else runs.
+  `packages/crawler/src/index.js` loads dotenv, calls `validateEnv()` from
+  `packages/crawler/src/env.js`, and only then dynamically imports `crawl.js` and calls
+  `crawl()`. `validateEnv` requires `NOTION_TOKEN`, `GCP_STORAGE_BUCKET_NAME` and
+  `GCP_STORAGE_SCRAPED_FILE_NAME`, treats absent, empty and whitespace-only values alike,
+  and throws a single error naming every missing variable without including any value. The
+  order is load-bearing: `notion.js` constructs its Notion client as it loads, and `crawl()`
+  uses the two storage variables only after `fetchData()` has finished
+  (`packages/crawler/src/crawl.js:11-14`), so validating first is what stops a missing
+  bucket name costing a complete crawl.
 
 ## Acceptance criteria
 
@@ -50,6 +60,14 @@ bucket. It is the first stage of the pipeline and the only component that talks 
   process exits with code 1 (unguarded).
 - Given a Notion children listing that fails, when content is gathered, then it is retried
   up to three times before that block's children are skipped (unguarded).
+- Given an environment where `NOTION_TOKEN`, `GCP_STORAGE_BUCKET_NAME` or
+  `GCP_STORAGE_SCRAPED_FILE_NAME` is absent, empty or whitespace-only, when `validateEnv()`
+  runs, then it throws one error naming every missing variable and no variable's value
+  (guarded: the `crawler validateEnv` suite).
+- Given any of those three variables missing, when `packages/crawler/src/index.js` is
+  loaded, then the module rejects with that error, the Notion client is never constructed
+  and no Notion search is issued (guarded: `loading the crawler entry point without its
+  environment rejects before the crawl starts`).
 
 ## Non-goals & boundaries
 
@@ -77,7 +95,8 @@ bucket. It is the first stage of the pipeline and the only component that talks 
   (`packages/crawler/src/utils.js:25`) and asserted in
   `packages/crawler/test/utils.test.js`.
 - Config: `NOTION_TOKEN`, `GCP_STORAGE_BUCKET_NAME`, `GCP_STORAGE_SCRAPED_FILE_NAME`,
-  `IS_LOCAL_ENVIRONMENT`.
+  `IS_LOCAL_ENVIRONMENT`. The first three are required, and validated at startup by
+  `packages/crawler/src/env.js`.
 - Holds no persistent state; the process is one-shot.
 
 ## Dependencies & interactions
@@ -89,7 +108,8 @@ bucket. It is the first stage of the pipeline and the only component that talks 
 
 ## Key flows
 
-1. `packages/crawler/src/index.js` calls `crawl()`.
+1. `packages/crawler/src/index.js` validates the environment, then imports and calls
+   `crawl()`.
 2. `fetchData()` pages through Notion search, then fetches each page's block content at
    concurrency 3, dropping pages with no text.
 3. `createCsv()` serialises the records; the CSV is written to the local file.
@@ -98,15 +118,19 @@ bucket. It is the first stage of the pipeline and the only component that talks 
 ## Tests & verification
 
 Tests live in `packages/crawler/test/` and run with `npm test --workspace=crawler`
-(`node --test --experimental-test-module-mocks`). Four tests, all passing as of 2026-09-09:
+(`node --test --experimental-test-module-mocks`). Ten tests, all passing as of 2026-09-10:
 `crawl`, `notion > fetchData returns correct parsed data` (snapshot),
-`notion > getPages works correctly with pagination`, `createCsv works correctly`.
+`notion > getPages works correctly with pagination`, `createCsv works correctly`, the five
+cases in the `crawler validateEnv` suite, and `loading the crawler entry point without its
+environment rejects before the crawl starts`.
 
 Not covered: the retry and 500ms-delay behavior in `getRecursiveBlockContent`, the
 local-vs-bucket branch of `upload`, and the `process.exit(1)` error path.
 
 ## Related code
 
+- `packages/crawler/src/index.js`
+- `packages/crawler/src/env.js`
 - `packages/crawler/src/crawl.js`
 - `packages/crawler/src/notion.js`
 - `packages/crawler/src/utils.js`

--- a/docs/embeddings-creation.md
+++ b/docs/embeddings-creation.md
@@ -9,7 +9,7 @@ OpenAI, and writes the vectors back to the same bucket for the Slack bot to cons
 ## Behavior & rules
 
 - Registered as the `create_embeddings` CloudEvent handler
-  (`packages/embeddings-creation/src/index.js:5`); deployed as the `embedding-creation`
+  (`packages/embeddings-creation/src/index.js:11`); deployed as the `embedding-creation`
   Cloud Run function.
 - The handler returns early, logging a skip, unless the event's object name equals
   `GCP_STORAGE_SCRAPED_FILE_NAME` (`packages/embeddings-creation/src/create-embeddings.js:60`).
@@ -29,6 +29,17 @@ OpenAI, and writes the vectors back to the same bucket for the Slack bot to cons
   the whole run (`create-embeddings.js:107`).
 - The result is written to `GCP_STORAGE_EMBEDDING_FILE_NAME` and uploaded to the same
   bucket the event came from (`create-embeddings.js:119`).
+- The entry point validates the environment before the handler is registered.
+  `packages/embeddings-creation/src/index.js` loads dotenv, calls `validateEnv()` from
+  `packages/embeddings-creation/src/env.js`, and only then dynamically imports
+  `create-embeddings.js` to register it as the CloudEvent handler. `validateEnv` requires
+  `OPENAI_API_KEY`, `GCP_STORAGE_SCRAPED_FILE_NAME` and `GCP_STORAGE_EMBEDDING_FILE_NAME`,
+  treats absent, empty and whitespace-only values alike, and throws a single error naming
+  every missing variable without including any value. `GCP_STORAGE_BUCKET_NAME` is
+  deliberately not required: the bucket comes off the CloudEvent
+  (`packages/embeddings-creation/src/create-embeddings.js:57`). The dynamic import is what
+  keeps the OpenAI client, built at that module's top level, from being constructed before
+  the check runs.
 
 ## Acceptance criteria
 
@@ -60,6 +71,14 @@ OpenAI, and writes the vectors back to the same bucket for the Slack bot to cons
   and the `"."` as a defect to remove.
 - Given a transient OpenAI failure, when a chunk is embedded, then the call is made up to
   5 times in total (4 retries) with a 5s maximum delay before the run fails (unguarded).
+- Given an environment where `OPENAI_API_KEY`, `GCP_STORAGE_SCRAPED_FILE_NAME` or
+  `GCP_STORAGE_EMBEDDING_FILE_NAME` is absent, empty or whitespace-only, when
+  `validateEnv()` runs, then it throws one error naming every missing variable and no
+  variable's value (guarded: the `embeddings-creation validateEnv` suite).
+- Given only `GCP_STORAGE_BUCKET_NAME` is absent, when `validateEnv()` runs, then it does
+  not throw, because the bucket arrives on the CloudEvent (guarded:
+  `embeddings-creation validateEnv > does not require a bucket name, which arrives on the
+  CloudEvent`).
 
 ## Non-goals & boundaries
 
@@ -89,7 +108,8 @@ OpenAI, and writes the vectors back to the same bucket for the Slack bot to cons
   (`packages/embeddings-creation/src/create-embeddings.js:8`) and `MAX_TOKENS = 500`
   (`packages/embeddings-creation/src/create-embeddings.js:11`).
 - Config: `OPENAI_API_KEY`, `GCP_STORAGE_SCRAPED_FILE_NAME`,
-  `GCP_STORAGE_EMBEDDING_FILE_NAME`, `IS_LOCAL_ENVIRONMENT`.
+  `GCP_STORAGE_EMBEDDING_FILE_NAME`, `IS_LOCAL_ENVIRONMENT`. The first three are required,
+  and validated at startup by `packages/embeddings-creation/src/env.js`.
 - The whole corpus is held in memory during a run, which is why the function is deployed
   with 2GiB.
 
@@ -103,24 +123,27 @@ OpenAI, and writes the vectors back to the same bucket for the Slack bot to cons
 
 ## Key flows
 
-1. A finalize event arrives; the object name is checked against the scraped file name.
-2. The object is downloaded and parsed; empty-text records are dropped and each record is
+1. The entry point validates the environment, then registers the handler.
+2. A finalize event arrives; the object name is checked against the scraped file name.
+3. The object is downloaded and parsed; empty-text records are dropped and each record is
    token counted.
-3. Over-long records are chunked; every chunk is embedded with retry at concurrency 10.
-4. The rows are serialised to CSV, written locally, and uploaded to the bucket.
+4. Over-long records are chunked; every chunk is embedded with retry at concurrency 10.
+5. The rows are serialised to CSV, written locally, and uploaded to the bucket.
 
 ## Tests & verification
 
 Tests live in `packages/embeddings-creation/test/` and run with
 `npm test --workspace=embeddings-creation`; the script supplies the two `GCP_STORAGE_*`
-names via `cross-env`. One test, `embeddings creation`, passing as of 2026-09-09.
+names via `cross-env`. Seven tests, all passing as of 2026-09-10: `embeddings creation`
+and the six cases in the `embeddings-creation validateEnv` suite.
 
-That single test covers the happy path end to end with mocked storage and OpenAI. The
+`embeddings creation` covers the happy path end to end with mocked storage and OpenAI. The
 skip-on-wrong-object-name branch, `splitIntoMany`, and the backoff *retry* branch are uncovered. `backOff` itself runs on
 the happy path, so it is the retry, not the wrapper, that is unexercised.
 
 ## Related code
 
 - `packages/embeddings-creation/src/create-embeddings.js`
+- `packages/embeddings-creation/src/env.js`
 - `packages/embeddings-creation/src/index.js`
 - `packages/embeddings-creation/src/utils.js`

--- a/docs/embeddings-creation.md
+++ b/docs/embeddings-creation.md
@@ -134,8 +134,9 @@ OpenAI, and writes the vectors back to the same bucket for the Slack bot to cons
 
 Tests live in `packages/embeddings-creation/test/` and run with
 `npm test --workspace=embeddings-creation`; the script supplies the two `GCP_STORAGE_*`
-names via `cross-env`. Seven tests, all passing as of 2026-09-10: `embeddings creation`
-and the six cases in the `embeddings-creation validateEnv` suite.
+names via `cross-env`. Eight tests, all passing as of 2026-09-10: `embeddings creation`,
+the six cases in the `embeddings-creation validateEnv` suite, and `loading the embeddings
+entry point without its environment rejects before the OpenAI client is constructed`.
 
 `embeddings creation` covers the happy path end to end with mocked storage and OpenAI. The
 skip-on-wrong-object-name branch, `splitIntoMany`, and the backoff *retry* branch are uncovered. `backOff` itself runs on

--- a/docs/knowledge/architecture/external-integrations.md
+++ b/docs/knowledge/architecture/external-integrations.md
@@ -76,9 +76,9 @@ entry point therefore validates and then `await import()`s the app module. The c
 the sharpest case: `crawl()` runs the entire Notion crawl in `fetchData()` and only uses
 the storage variables afterwards (`packages/crawler/src/crawl.js:11-14`), so before this a
 missing bucket name burned a complete crawl before failing. That ordering is pinned by
-`packages/slack-bot/test/startupValidation.test.js` and
-`packages/crawler/test/startupValidation.test.js`, which assert the entry-point import
-rejects and that no client was constructed.
+a `test/startupValidation.test.js` in each of
+the three packages, which assert the entry-point import rejects and that no client was
+constructed.
 
 `MAX_CONTEXT_TOKENS` is deliberately outside all of this: it is optional with a default,
 and `parsePositiveTokenCount` ([[context-token-budget]]) already handles it.

--- a/docs/knowledge/architecture/external-integrations.md
+++ b/docs/knowledge/architecture/external-integrations.md
@@ -3,13 +3,16 @@ title: External integrations
 type: architecture
 tags: [integrations, trust-boundaries, secrets]
 source_paths:
+  - packages/crawler/src/env.js
   - packages/crawler/src/notion.js
   - packages/slack-bot/src/bot.js
+  - packages/slack-bot/src/env.js
   - packages/slack-bot/src/getAnswer.js
   - packages/embeddings-creation/src/create-embeddings.js
+  - packages/embeddings-creation/src/env.js
 source_commit: 4a9f973
 created: 2026-09-09
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # External integrations
@@ -30,10 +33,10 @@ exists: Bolt's `ExpressReceiver` verifies `/slack/events` against the signing se
 `/healthz` route is deliberately mounted **outside** that receiver and is therefore
 unauthenticated. See [[slack-event-surface]].
 
-## No credential is validated before use
+## Every credential is checked at startup
 
-Every secret in the table above is read from `process.env` and handed straight to a
-constructor, with no null check, no empty-string guard and no startup assertion:
+Each secret in the table above is still read from `process.env` and handed straight to a
+constructor, at module scope:
 
 | Credential | Read at |
 |---|---|
@@ -45,16 +48,40 @@ constructor, with no null check, no empty-string guard and no startup assertion:
 The GCP bucket and project names are read the same way at module scope
 (`packages/slack-bot/src/getAnswer.js:21-22`).
 
-**So a misconfigured deployment starts cleanly and fails later**, at the first request or
-the first bucket call, with whatever opaque error the client library raises rather than a
-message naming the missing variable. On a Cloud function that means the failure surfaces to
-a user asking a question, not to whoever deployed it.
+What changed is that nothing gets that far with a hole in the environment. Each package
+has a `src/env.js` exporting `validateEnv(env = process.env)`, and each entry point calls
+it as its first act:
 
-`MAX_CONTEXT_TOKENS` is the **only** environment variable the codebase validates, via
-`parsePositiveTokenCount` ([[context-token-budget]]) — and that exists because a bad value
-silently produced a zero-token context, not because config validation was adopted as a
-pattern. A single validate-on-startup function called before the constructors would turn
-every one of these into a deploy-time failure. There is no such function today.
+| Entry point | Requires |
+|---|---|
+| `packages/crawler/src/index.js` | `NOTION_TOKEN`, `GCP_STORAGE_BUCKET_NAME`, `GCP_STORAGE_SCRAPED_FILE_NAME` |
+| `packages/embeddings-creation/src/index.js` | `OPENAI_API_KEY`, `GCP_STORAGE_SCRAPED_FILE_NAME`, `GCP_STORAGE_EMBEDDING_FILE_NAME` |
+| `packages/slack-bot/src/index.js`, `dev.js` | `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`, `OPENAI_API_KEY`, `GCP_STORAGE_BUCKET_NAME`, `GCP_STORAGE_EMBEDDING_FILE_NAME`, plus `GCP_PROJECT_ID` and `GCP_EMBEDDING_SUBSCRIPTION` unless `IS_LOCAL_ENVIRONMENT` is set |
+
+The sets come from `.github/workflows/deploy-step.yml` ([[deploy-step-commands]]) rather
+than from the README, which is why the bucket is absent from embeddings-creation: that one
+arrives on the CloudEvent, not from the environment. The bot's two Pub/Sub variables are
+conditional because they exist only to name the subscription that
+[[embedding-lifecycle-and-warm-start]] skips locally.
+
+Absent, empty and whitespace-only all count as missing. Every missing name is collected
+and reported in one error, so a fresh deployment is told about all of its holes at once
+rather than one per redeploy, and no value ever reaches the message because these are
+secrets.
+
+**The ordering is the whole trick.** ESM evaluates an imported module's body before its
+importer's, so a `validateEnv()` sitting below a static `import` of `bot.js` would run
+after the Bolt receiver, the Bolt app and the OpenAI client had already been built. Each
+entry point therefore validates and then `await import()`s the app module. The crawler is
+the sharpest case: `crawl()` runs the entire Notion crawl in `fetchData()` and only uses
+the storage variables afterwards (`packages/crawler/src/crawl.js:11-14`), so before this a
+missing bucket name burned a complete crawl before failing. That ordering is pinned by
+`packages/slack-bot/test/startupValidation.test.js` and
+`packages/crawler/test/startupValidation.test.js`, which assert the entry-point import
+rejects and that no client was constructed.
+
+`MAX_CONTEXT_TOKENS` is deliberately outside all of this: it is optional with a default,
+and `parsePositiveTokenCount` ([[context-token-budget]]) already handles it.
 
 ## The data-egress boundary worth being deliberate about
 

--- a/docs/knowledge/architecture/local-environment-emulation.md
+++ b/docs/knowledge/architecture/local-environment-emulation.md
@@ -6,10 +6,11 @@ source_paths:
   - packages/crawler/src/utils.js
   - packages/embeddings-creation/src/utils.js
   - packages/slack-bot/src/utils.js
+  - packages/slack-bot/src/env.js
   - Makefile
 source_commit: 633de22
 created: 2026-09-09
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # Local environment emulation
@@ -53,3 +54,10 @@ branch. It lives in a file of its own for two reasons: the deletion is process-w
 
 Note also that `IS_LOCAL_ENVIRONMENT` is truthy for *any* non-empty value, `"false"`
 included.
+
+The flag has one other job: `packages/slack-bot/src/env.js` reads it with the same
+`Boolean` semantics, off its own `env` argument rather than by importing `utils.js`, and
+requires `GCP_PROJECT_ID` and `GCP_EMBEDDING_SUBSCRIPTION` only when it is falsy. Those
+two exist solely to name the Pub/Sub subscription a local run never creates, so requiring
+them unconditionally would stop `make bot-start` for a developer who has no Pub/Sub
+configured at all. See [[external-integrations]].

--- a/docs/knowledge/concepts/test-strategy-module-mocks.md
+++ b/docs/knowledge/concepts/test-strategy-module-mocks.md
@@ -65,8 +65,8 @@ answering path is no longer in that group: `messageEvents.test.js`,
 
 One reporting quirk: node's default glob executes the fixture modules under
 `test/mocks/` as test files, so the runner's 116 for slack-bot includes two files
-containing no tests. There are 131 real tests across the repo, 133 reported: 10 in crawler,
-7 in embeddings-creation, and 114 of slack-bot's 116.
+containing no tests. There are 132 real tests across the repo, 134 reported: 10 in crawler,
+8 in embeddings-creation, and 114 of slack-bot's 116.
 
 Vendored guidance for this repo now lives in `.agents/skills/test-unit-guidelines/` and
 `.agents/skills/test-review/`.

--- a/docs/knowledge/concepts/test-strategy-module-mocks.md
+++ b/docs/knowledge/concepts/test-strategy-module-mocks.md
@@ -8,7 +8,7 @@ source_paths:
   - packages/slack-bot/test
 source_commit: 4a9f973
 created: 2026-09-09
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # Test strategy and module mocks
@@ -64,9 +64,9 @@ answering path is no longer in that group: `messageEvents.test.js`,
 `messageHandler.test.js` and `transcribe.test.js` cover it.
 
 One reporting quirk: node's default glob executes the fixture modules under
-`test/mocks/` as test files, so the runner's 105 for slack-bot includes two files
-containing no tests. There are 108 real tests across the repo, 110 reported: 4 in crawler,
-1 in embeddings-creation, and 103 of slack-bot's 105.
+`test/mocks/` as test files, so the runner's 116 for slack-bot includes two files
+containing no tests. There are 131 real tests across the repo, 133 reported: 10 in crawler,
+7 in embeddings-creation, and 114 of slack-bot's 116.
 
 Vendored guidance for this repo now lives in `.agents/skills/test-unit-guidelines/` and
 `.agents/skills/test-review/`.

--- a/docs/knowledge/modules/crawler-module.md
+++ b/docs/knowledge/modules/crawler-module.md
@@ -4,12 +4,13 @@ type: module
 tags: [notion, crawl, cloud-run-job]
 source_paths:
   - packages/crawler/src/crawl.js
+  - packages/crawler/src/env.js
   - packages/crawler/src/notion.js
   - packages/crawler/src/utils.js
   - packages/crawler/src/csv.js
 source_commit: c4bc5ac
 created: 2026-09-09
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # Crawler module
@@ -20,9 +21,12 @@ It discovers pages, flattens each page's block tree to one line of text, and wri
 
 ## Shape
 
-`src/index.js` calls `crawl()`, which is a four-step orchestration with a single
-`try`/`catch` that logs and `process.exit(1)`s. Everything interesting is in
-`src/notion.js`.
+`src/index.js` calls `validateEnv()` from `src/env.js`, then dynamically imports
+`src/crawl.js` and calls `crawl()`, which is a four-step orchestration with a single
+`try`/`catch` that logs and `process.exit(1)`s. The validate-then-import order matters:
+`crawl()` uses the storage variables only after the whole Notion crawl has finished, so
+checking them up front is what stops a missing bucket name costing a complete crawl. See
+[[external-integrations]]. Everything interesting is in `src/notion.js`.
 
 ## The two-phase Notion read
 

--- a/docs/knowledge/modules/embeddings-creation-module.md
+++ b/docs/knowledge/modules/embeddings-creation-module.md
@@ -30,7 +30,10 @@ because there is nothing to layer.
 `src/create-embeddings.js` and registers the handler. The dynamic import is what keeps the
 OpenAI client, built at that module's top level, from being constructed before the check
 runs. `GCP_STORAGE_BUCKET_NAME` is deliberately not required here: the bucket comes off
-the CloudEvent. See [[external-integrations]].
+the CloudEvent. `test/startupValidation.test.js` pins that ordering: it clears the
+required variables (including the two the test script sets via `cross-env`) and asserts
+the entry-point import rejects with the OpenAI constructor never called. See
+[[external-integrations]].
 
 ## The self-trigger guard
 

--- a/docs/knowledge/modules/embeddings-creation-module.md
+++ b/docs/knowledge/modules/embeddings-creation-module.md
@@ -4,11 +4,12 @@ type: module
 tags: [openai, embeddings, cloud-function, cloudevent]
 source_paths:
   - packages/embeddings-creation/src/create-embeddings.js
+  - packages/embeddings-creation/src/env.js
   - packages/embeddings-creation/src/index.js
   - packages/embeddings-creation/src/utils.js
 source_commit: c4bc5ac
 created: 2026-09-09
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # Embeddings creation module
@@ -22,6 +23,14 @@ A single CloudEvent handler, `create_embeddings`, that turns `scraped.csv` into
 `createEmbeddings(event)` does five things in sequence: guard the event, download and
 parse, token-count and chunk, embed with retry, write and upload. There is no layering
 because there is nothing to layer.
+
+## Startup validation before the client
+
+`src/index.js` calls `validateEnv()` from `src/env.js`, then dynamically imports
+`src/create-embeddings.js` and registers the handler. The dynamic import is what keeps the
+OpenAI client, built at that module's top level, from being constructed before the check
+runs. `GCP_STORAGE_BUCKET_NAME` is deliberately not required here: the bucket comes off
+the CloudEvent. See [[external-integrations]].
 
 ## The self-trigger guard
 

--- a/docs/knowledge/modules/slack-bot-module.md
+++ b/docs/knowledge/modules/slack-bot-module.md
@@ -8,11 +8,12 @@ source_paths:
   - packages/slack-bot/src/getAnswer.js
   - packages/slack-bot/src/summarize.js
   - packages/slack-bot/src/utils.js
+  - packages/slack-bot/src/env.js
   - packages/slack-bot/src/index.js
   - packages/slack-bot/src/dev.js
 source_commit: 4a9f973
 created: 2026-09-09
-updated: 2026-09-09
+updated: 2026-09-10
 ---
 
 # Slack bot module
@@ -42,11 +43,15 @@ the retrieval machinery.
 | `src/getAnswer.js` | data-set lifecycle, context assembly, the completion call |
 | `src/summarize.js` | the shortcut handler for links and files |
 | `src/utils.js` | storage download, CSV parse, distance maths, audio download and transcription |
-| `src/index.js` | exports the Express app as `slackBot` for the functions framework |
-| `src/dev.js` | starts Bolt directly for local development |
+| `src/env.js` | the required-variable list and `validateEnv()`, called by both entry points |
+| `src/index.js` | validates the environment, then exports the Express app as `slackBot` for the functions framework |
+| `src/dev.js` | validates the environment, then starts Bolt directly for local development |
 
 `src/index.js` and `src/dev.js` are two entry points to the same app: the function runtime
-serves the Express app, while `npm run dev` uses Bolt's own listener.
+serves the Express app, while `npm run dev` uses Bolt's own listener. Both call
+`validateEnv()` before importing `src/bot.js`, and both import it dynamically for that
+reason: `src/bot.js` builds its receiver, app and OpenAI client as it loads, so a static
+import would run all of that first. See [[external-integrations]].
 
 `src/messageEvents.js` holds no I/O and imports nothing. Its job is to keep the "should we
 act on this?" decisions out of the handler, where they could only be tested by standing up
@@ -67,7 +72,7 @@ free of anything sensitive. See [[slack-event-surface]].
 
 ## Test coverage is uneven, but far less so than it was
 
-The workspace reports 105 tests in 14 suites, 103 of them real: node's default glob also
+The workspace reports 116 tests in 15 suites, 114 of them real: node's default glob also
 executes the two test-less fixture modules under `test/mocks/`.
 
 Well covered:
@@ -83,6 +88,9 @@ Well covered:
 - The `message` handler in `bot.js`, through a mocked `@slack/bolt` that captures the
   registered handler (`packages/slack-bot/test/messageHandler.test.js`): every branch of the
   attachment and transcription flow, and each fire-and-forget rejection.
+- `env.js` and the entry point's validate-before-import order
+  (`packages/slack-bot/test/env.test.js`,
+  `packages/slack-bot/test/startupValidation.test.js`).
 
 The rest of `utils.js` is covered in part: `download`
 (`packages/slack-bot/test/download.test.js`) and `distancesFromEmbeddings`

--- a/docs/knowledge/tours/start-here.md
+++ b/docs/knowledge/tours/start-here.md
@@ -66,7 +66,6 @@ Each is described in its own note; collected here so nobody rediscovers them the
 | A downloaded audio file is always named `.mp4` whatever Slack actually sent, so the name is no evidence of the format | [[audio-transcription-path]] |
 | Notion child-block listing is not paginated, so large pages are silently truncated | [[crawler-module]] |
 | A failed Pub/Sub reload is unlogged and unretried after the ack, so the bot serves stale embeddings silently | [[embedding-lifecycle-and-warm-start]] |
-| No credential is validated at startup, so a missing secret fails at first request rather than at deploy | [[external-integrations]] |
 | The deploy workflow never creates the Pub/Sub topic, and its notification step never runs | [[gcp-deployment-topology]] |
 | A persistently failing Notion block subtree is skipped silently | [[resilience-and-rate-limiting]] |
 | `summarize.js`, `/healthz` and the Pub/Sub refresh path have no tests at all | [[test-strategy-module-mocks]] |

--- a/docs/slack-bot.md
+++ b/docs/slack-bot.md
@@ -49,6 +49,27 @@ before answering them, and summarises links and files on request.
 - The download target is `/tmp/embeddings-<pid>.csv`, per process, so concurrent processes
   never share a file (`getAnswer.js:26`).
 
+### Startup validation
+
+- Both entry points validate the environment before `bot.js` is loaded.
+  `packages/slack-bot/src/index.js` and `packages/slack-bot/src/dev.js` load dotenv, call
+  `validateEnv()` from `packages/slack-bot/src/env.js`, and only then dynamically import
+  `bot.js`. `validateEnv` always requires `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`,
+  `OPENAI_API_KEY`, `GCP_STORAGE_BUCKET_NAME` and `GCP_STORAGE_EMBEDDING_FILE_NAME`, and
+  additionally `GCP_PROJECT_ID` and `GCP_EMBEDDING_SUBSCRIPTION` when
+  `IS_LOCAL_ENVIRONMENT` is falsy. It treats absent, empty and whitespace-only values
+  alike, and throws a single error naming every missing variable without including any
+  value.
+- The two Pub/Sub variables are conditional because they exist only to build the
+  subscription name (`getAnswer.js:85`), a path skipped in the local environment
+  (`getAnswer.js:60`).
+- The dynamic import is load-bearing: `bot.js` builds its `ExpressReceiver`, its Bolt
+  `App` and its OpenAI client as it loads, and ESM evaluates an imported module's body
+  before its importer's, so a static import would construct all three before the check
+  ran.
+- `MAX_CONTEXT_TOKENS` is outside this: it is optional with a default, and is handled by
+  `parsePositiveTokenCount`.
+
 ### Slack surface
 
 - Bolt uses `ExpressReceiver`, so Slack requests to `/slack/events` are verified against
@@ -231,6 +252,18 @@ before answering them, and summarises links and files on request.
   `try`/`catch`, and since the message is already acked Pub/Sub will not redeliver, so the
   bot serves the previous corpus until a later message or a restart. Treat this criterion
   as the invariant to restore.
+- Given an environment missing any always-required variable, when `validateEnv()` runs,
+  then it throws one error naming every missing variable and no variable's value (guarded:
+  the `slack-bot validateEnv` suite).
+- Given `IS_LOCAL_ENVIRONMENT` is unset, when `validateEnv()` runs, then `GCP_PROJECT_ID`
+  and `GCP_EMBEDDING_SUBSCRIPTION` are required; given it is set to a truthy value, they
+  are not (guarded: `slack-bot validateEnv > requires the Pub/Sub variables when
+  IS_LOCAL_ENVIRONMENT is unset` and `... does not require the Pub/Sub variables when
+  IS_LOCAL_ENVIRONMENT is set`).
+- Given the required variables are absent, when `packages/slack-bot/src/index.js` is
+  loaded, then the module rejects with an error naming them and no `ExpressReceiver`, Bolt
+  `App` or OpenAI client is constructed (guarded: `loading the slack bot entry point
+  without its environment rejects before any client is constructed`).
 
 ## Non-goals & boundaries
 
@@ -274,7 +307,10 @@ before answering them, and summarises links and files on request.
 - Local cache file `/tmp/embeddings-<pid>.csv`.
 - Config: `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`, `OPENAI_API_KEY`, `GCP_PROJECT_ID`,
   `GCP_STORAGE_BUCKET_NAME`, `GCP_STORAGE_EMBEDDING_FILE_NAME`,
-  `GCP_EMBEDDING_SUBSCRIPTION`, `MAX_CONTEXT_TOKENS`, `IS_LOCAL_ENVIRONMENT`.
+  `GCP_EMBEDDING_SUBSCRIPTION`, `MAX_CONTEXT_TOKENS`, `IS_LOCAL_ENVIRONMENT`. All but the
+  last two are required and validated at startup by `packages/slack-bot/src/env.js`, with
+  `GCP_PROJECT_ID` and `GCP_EMBEDDING_SUBSCRIPTION` required only outside the local
+  environment.
 - Slack OAuth scopes and the `message.im` bot event subscription are declared in `slack_manifest.yaml`. The `summarize` shortcut is registered in code at `packages/slack-bot/src/summarize.js:20`, not in the manifest.
 - The non-user `message` subtype deny list is a module-scope `Set` at
   `packages/slack-bot/src/messageEvents.js:35-64`. It is configuration expressed in code
@@ -298,7 +334,8 @@ before answering them, and summarises links and files on request.
    awaited threw.
 2. **Context assembly.** Embed the question → cosine distances over the data set → sort
    ascending → take chunks until the token budget is spent → build the prompt → complete.
-3. **Startup.** Import kicks off the embeddings load → the startup probe on `/healthz`
+3. **Startup.** The entry point validates the environment, then imports `bot.js` →
+   import kicks off the embeddings load → the startup probe on `/healthz`
    awaits it → once loaded, subscribe to embedding updates (non-local only).
 4. **Refresh.** `OBJECT_FINALIZE` for the embeddings object → ack → reload the data set.
 5. **Summarise.** Shortcut → for each attached file, fetch and base64 it, then summarise;
@@ -307,9 +344,9 @@ before answering them, and summarises links and files on request.
 ## Tests & verification
 
 Tests live in `packages/slack-bot/test/` (fixtures in `test/mocks/`) and run with
-`npm test --workspace=slack-bot`. The workspace reports 105 passing tests in 14 suites as of
-2026-09-09. Two of the 105 are the test-less fixture modules in `test/mocks/`, which node's
-default glob executes as test files, so there are 103 real tests across these nine files:
+`npm test --workspace=slack-bot`. The workspace reports 116 passing tests in 15 suites as of
+2026-09-10. Two of the 116 are the test-less fixture modules in `test/mocks/`, which node's
+default glob executes as test files, so there are 114 real tests across these eleven files:
 
 | File | Covers |
 |---|---|
@@ -322,6 +359,8 @@ default glob executes as test files, so there are 103 real tests across these ni
 | `test/messageEvents.test.js` | five of the six predicates directly, including every deny-list subtype |
 | `test/messageHandler.test.js` | the `message` handler, through a stubbed Bolt app and `client` |
 | `test/transcribe.test.js` | `downloadAudio`, `transcribe` and `transcriptionText` |
+| `test/env.test.js` | `validateEnv`: the required sets, the conditional Pub/Sub pair, and that no value is leaked |
+| `test/startupValidation.test.js` | that `src/index.js` rejects before any client is constructed |
 
 Coverage is now broad but not uniform. `packages/slack-bot/src/getAnswer.js`,
 `packages/slack-bot/src/messageEvents.js` (bar `hasAttachments`, reached only through
@@ -345,4 +384,5 @@ testable at all.
 - `packages/slack-bot/src/messageEvents.js`
 - `packages/slack-bot/src/summarize.js`
 - `packages/slack-bot/src/utils.js`
+- `packages/slack-bot/src/env.js`
 - `packages/slack-bot/src/index.js`, `packages/slack-bot/src/dev.js`

--- a/packages/crawler/AGENTS.md
+++ b/packages/crawler/AGENTS.md
@@ -12,7 +12,8 @@ job (`crawler-job`) on a Cloud Scheduler trigger.
 
 | File | Role |
 |---|---|
-| `src/index.js` | Entry point: calls `crawl()`. |
+| `src/index.js` | Entry point: calls `validateEnv()`, then dynamically imports and calls `crawl()`. |
+| `src/env.js` | `requiredEnvironmentVariables` and `validateEnv()`, which throws naming every missing variable. |
 | `src/crawl.js` | Orchestrates fetch, CSV, write, upload. Exits `1` on failure. |
 | `src/notion.js` | Notion search pagination and recursive block-content extraction. |
 | `src/utils.js` | `upload()` and `createCsv()`; `upload` copies to `.cache/` when local. |
@@ -30,6 +31,13 @@ npm run lint --workspace=crawler
 
 `NOTION_TOKEN`, `GCP_STORAGE_BUCKET_NAME`, `GCP_STORAGE_SCRAPED_FILE_NAME`, and
 `IS_LOCAL_ENVIRONMENT` for local runs.
+
+The first three are required: `src/index.js` calls `validateEnv()` before anything else,
+so a missing, empty or whitespace-only value fails the run at startup with every missing
+name in one error rather than part way through a crawl. `IS_LOCAL_ENVIRONMENT` is not
+validated. The dynamic import of `crawl.js` is what keeps that check ahead of the Notion
+client, which `notion.js` constructs as it loads: `test/startupValidation.test.js` pins
+the ordering, so do not turn it back into a static import.
 
 ## Notes for changes
 

--- a/packages/crawler/src/env.js
+++ b/packages/crawler/src/env.js
@@ -1,0 +1,34 @@
+/**
+ * Every environment variable the crawler cannot run without, as set by
+ * `.github/workflows/deploy-step.yml`.
+ */
+export const requiredEnvironmentVariables = [
+  'NOTION_TOKEN',
+  'GCP_STORAGE_BUCKET_NAME',
+  'GCP_STORAGE_SCRAPED_FILE_NAME'
+]
+
+const isMissing = value =>
+  typeof value !== 'string' || value.trim().length === 0
+
+/**
+ * Fail fast when the crawler is misconfigured. Called from the entry point
+ * before the Notion client is constructed, so a missing variable is named at
+ * startup rather than costing a whole crawl or surfacing as a client-library
+ * error. Every missing name is reported at once; no value is ever included in
+ * the message, because these are secrets.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @throws {Error} if any required variable is absent, empty or whitespace-only
+ */
+export function validateEnv(env = process.env) {
+  const missing = requiredEnvironmentVariables.filter(name =>
+    isMissing(env[name])
+  )
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(', ')}`
+    )
+  }
+}

--- a/packages/crawler/src/index.js
+++ b/packages/crawler/src/index.js
@@ -1,3 +1,12 @@
-import { crawl } from '../src/crawl.js'
+import 'dotenv/config'
+import { validateEnv } from './env.js'
+
+validateEnv()
+
+// Dynamic so notion.js does not construct its client, and crawl() cannot start
+// a crawl, until the environment has been checked. crawl() only uses the
+// storage variables after fetchData() has finished, so validating here is what
+// stops a missing bucket name costing a complete crawl.
+const { crawl } = await import('./crawl.js')
 
 crawl()

--- a/packages/crawler/test/env.test.js
+++ b/packages/crawler/test/env.test.js
@@ -1,0 +1,75 @@
+import { describe, test } from 'node:test'
+
+import { requiredEnvironmentVariables, validateEnv } from '../src/env.js'
+
+const completeEnvironment = {
+  NOTION_TOKEN: 'notion-token-value',
+  GCP_STORAGE_BUCKET_NAME: 'bucket-name',
+  GCP_STORAGE_SCRAPED_FILE_NAME: 'scraped.csv'
+}
+
+describe('crawler validateEnv', () => {
+  test('returns without throwing when every required variable is present', t => {
+    t.assert.doesNotThrow(() => validateEnv({ ...completeEnvironment }))
+  })
+
+  test('requires exactly the variables the crawler deployment sets', t => {
+    t.assert.deepStrictEqual(requiredEnvironmentVariables, [
+      'NOTION_TOKEN',
+      'GCP_STORAGE_BUCKET_NAME',
+      'GCP_STORAGE_SCRAPED_FILE_NAME'
+    ])
+  })
+
+  test('names every missing variable in one error, not only the first', t => {
+    const environmentMissingTwoVariables = { ...completeEnvironment }
+    delete environmentMissingTwoVariables.NOTION_TOKEN
+    delete environmentMissingTwoVariables.GCP_STORAGE_SCRAPED_FILE_NAME
+
+    t.assert.throws(
+      () => validateEnv(environmentMissingTwoVariables),
+      error => {
+        t.assert.match(error.message, /NOTION_TOKEN/)
+        t.assert.match(error.message, /GCP_STORAGE_SCRAPED_FILE_NAME/)
+        return true
+      }
+    )
+  })
+
+  test('counts an empty string and a whitespace-only value as missing', t => {
+    t.assert.throws(
+      () =>
+        validateEnv({
+          ...completeEnvironment,
+          NOTION_TOKEN: '',
+          GCP_STORAGE_BUCKET_NAME: '   '
+        }),
+      error => {
+        t.assert.match(error.message, /NOTION_TOKEN/)
+        t.assert.match(error.message, /GCP_STORAGE_BUCKET_NAME/)
+        return true
+      }
+    )
+  })
+
+  test('does not put the value of a present variable in the message', t => {
+    const recognisableSecretValue = 'secret-notion-token-never-printed'
+    const environmentMissingBucketName = {
+      ...completeEnvironment,
+      NOTION_TOKEN: recognisableSecretValue
+    }
+    delete environmentMissingBucketName.GCP_STORAGE_BUCKET_NAME
+
+    t.assert.throws(
+      () => validateEnv(environmentMissingBucketName),
+      error => {
+        t.assert.doesNotMatch(
+          error.message,
+          new RegExp(recognisableSecretValue)
+        )
+        t.assert.match(error.message, /GCP_STORAGE_BUCKET_NAME/)
+        return true
+      }
+    )
+  })
+})

--- a/packages/crawler/test/startupValidation.test.js
+++ b/packages/crawler/test/startupValidation.test.js
@@ -1,0 +1,61 @@
+import { after, before, test, mock } from 'node:test'
+import sinon from 'sinon'
+
+// notion.js constructs its Notion client as it loads, and crawl() runs the
+// whole Notion crawl before it ever touches the storage variables, so a
+// missing bucket name used to cost a complete crawl. index.js validates first
+// and imports crawl.js dynamically: the assertions here are that the import
+// rejects, that the Notion client was never constructed, and that no Notion
+// search was issued, which is fetchData's first act. dotenv/config is
+// neutralised so a developer's local .env cannot decide the outcome.
+
+const notionConstructorSpy = sinon.spy()
+const notionSearchSpy = sinon.spy()
+
+class NotionClientMock {
+  constructor(...args) {
+    notionConstructorSpy(...args)
+  }
+  search = notionSearchSpy
+  blocks = { children: { list: () => {} } }
+}
+
+const environmentBeforeTest = { ...process.env }
+
+const variablesClearedForTest = [
+  'NOTION_TOKEN',
+  'GCP_STORAGE_BUCKET_NAME',
+  'GCP_STORAGE_SCRAPED_FILE_NAME'
+]
+
+before(() => {
+  mock.module('dotenv/config', {})
+  mock.module('@notionhq/client', {
+    namedExports: { Client: NotionClientMock }
+  })
+
+  for (const variableName of variablesClearedForTest) {
+    delete process.env[variableName]
+  }
+})
+
+after(() => {
+  process.env = { ...environmentBeforeTest }
+  mock.reset()
+  sinon.restore()
+})
+
+test('loading the crawler entry point without its environment rejects before the crawl starts', async t => {
+  await t.assert.rejects(
+    () => import('../src/index.js'),
+    error => {
+      t.assert.match(error.message, /NOTION_TOKEN/)
+      t.assert.match(error.message, /GCP_STORAGE_BUCKET_NAME/)
+      t.assert.match(error.message, /GCP_STORAGE_SCRAPED_FILE_NAME/)
+      return true
+    }
+  )
+
+  sinon.assert.notCalled(notionConstructorSpy)
+  sinon.assert.notCalled(notionSearchSpy)
+})

--- a/packages/embeddings-creation/AGENTS.md
+++ b/packages/embeddings-creation/AGENTS.md
@@ -13,7 +13,8 @@ same bucket, which in turn notifies the Slack bot over Pub/Sub.
 
 | File | Role |
 |---|---|
-| `src/index.js` | Registers the `create_embeddings` CloudEvent handler. |
+| `src/index.js` | Calls `validateEnv()`, then dynamically imports `create-embeddings.js` and registers the `create_embeddings` CloudEvent handler. |
+| `src/env.js` | `requiredEnvironmentVariables` and `validateEnv()`, which throws naming every missing variable. |
 | `src/create-embeddings.js` | Filter, chunk, embed, write, upload. |
 | `src/utils.js` | `download`, `upload`, `createCsv`, `parseCsv`; local mode uses `.cache/`. |
 
@@ -31,6 +32,15 @@ npm run lint --workspace=embeddings-creation
 `OPENAI_API_KEY`, `GCP_STORAGE_SCRAPED_FILE_NAME`, `GCP_STORAGE_EMBEDDING_FILE_NAME`, and
 `IS_LOCAL_ENVIRONMENT` for local runs. The test script sets the two `GCP_STORAGE_*` names
 itself via `cross-env`.
+
+The first three are required: `src/index.js` calls `validateEnv()` before anything else,
+so a missing, empty or whitespace-only value fails startup with every missing name in one
+error instead of an opaque client-library error on the first event. `GCP_STORAGE_BUCKET_NAME`
+is deliberately not required, because the bucket arrives on the CloudEvent, and
+`IS_LOCAL_ENVIRONMENT` is not validated. The dynamic import of `create-embeddings.js` is
+what keeps that check ahead of the OpenAI client and the two `GCP_STORAGE_*` reads at that
+module's top level: `test/startupValidation.test.js` pins the ordering, so do not turn it
+back into a static import.
 
 ## Notes for changes
 

--- a/packages/embeddings-creation/src/env.js
+++ b/packages/embeddings-creation/src/env.js
@@ -1,0 +1,36 @@
+/**
+ * Every environment variable the embeddings function cannot run without, as
+ * set by `.github/workflows/deploy-step.yml`. The bucket is deliberately not
+ * here: it arrives on the CloudEvent rather than from the environment
+ * (`src/create-embeddings.js`).
+ */
+export const requiredEnvironmentVariables = [
+  'OPENAI_API_KEY',
+  'GCP_STORAGE_SCRAPED_FILE_NAME',
+  'GCP_STORAGE_EMBEDDING_FILE_NAME'
+]
+
+const isMissing = value =>
+  typeof value !== 'string' || value.trim().length === 0
+
+/**
+ * Fail fast when the function is misconfigured. Called from the entry point
+ * before the OpenAI client is constructed, so a missing variable is named at
+ * startup rather than surfacing as a client-library error on the first event.
+ * Every missing name is reported at once; no value is ever included in the
+ * message, because these are secrets.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @throws {Error} if any required variable is absent, empty or whitespace-only
+ */
+export function validateEnv(env = process.env) {
+  const missing = requiredEnvironmentVariables.filter(name =>
+    isMissing(env[name])
+  )
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(', ')}`
+    )
+  }
+}

--- a/packages/embeddings-creation/src/index.js
+++ b/packages/embeddings-creation/src/index.js
@@ -1,5 +1,11 @@
 import 'dotenv/config'
 import * as ff from '@google-cloud/functions-framework'
-import { createEmbeddings } from './create-embeddings.js'
+import { validateEnv } from './env.js'
+
+validateEnv()
+
+// Dynamic so the OpenAI client create-embeddings.js builds as it loads is not
+// constructed until the environment has been checked.
+const { createEmbeddings } = await import('./create-embeddings.js')
 
 ff.cloudEvent('create_embeddings', createEmbeddings)

--- a/packages/embeddings-creation/test/env.test.js
+++ b/packages/embeddings-creation/test/env.test.js
@@ -1,0 +1,83 @@
+import { describe, test } from 'node:test'
+
+import { requiredEnvironmentVariables, validateEnv } from '../src/env.js'
+
+const completeEnvironment = {
+  OPENAI_API_KEY: 'openai-api-key-value',
+  GCP_STORAGE_SCRAPED_FILE_NAME: 'scraped.csv',
+  GCP_STORAGE_EMBEDDING_FILE_NAME: 'embeddings.csv'
+}
+
+describe('embeddings-creation validateEnv', () => {
+  test('returns without throwing when every required variable is present', t => {
+    t.assert.doesNotThrow(() => validateEnv({ ...completeEnvironment }))
+  })
+
+  test('requires exactly the variables the function deployment sets', t => {
+    t.assert.deepStrictEqual(requiredEnvironmentVariables, [
+      'OPENAI_API_KEY',
+      'GCP_STORAGE_SCRAPED_FILE_NAME',
+      'GCP_STORAGE_EMBEDDING_FILE_NAME'
+    ])
+  })
+
+  test('does not require a bucket name, which arrives on the CloudEvent', t => {
+    t.assert.strictEqual(
+      requiredEnvironmentVariables.includes('GCP_STORAGE_BUCKET_NAME'),
+      false
+    )
+    t.assert.doesNotThrow(() => validateEnv({ ...completeEnvironment }))
+  })
+
+  test('names every missing variable in one error, not only the first', t => {
+    const environmentMissingTwoVariables = { ...completeEnvironment }
+    delete environmentMissingTwoVariables.OPENAI_API_KEY
+    delete environmentMissingTwoVariables.GCP_STORAGE_EMBEDDING_FILE_NAME
+
+    t.assert.throws(
+      () => validateEnv(environmentMissingTwoVariables),
+      error => {
+        t.assert.match(error.message, /OPENAI_API_KEY/)
+        t.assert.match(error.message, /GCP_STORAGE_EMBEDDING_FILE_NAME/)
+        return true
+      }
+    )
+  })
+
+  test('counts an empty string and a whitespace-only value as missing', t => {
+    t.assert.throws(
+      () =>
+        validateEnv({
+          ...completeEnvironment,
+          OPENAI_API_KEY: '',
+          GCP_STORAGE_SCRAPED_FILE_NAME: '   '
+        }),
+      error => {
+        t.assert.match(error.message, /OPENAI_API_KEY/)
+        t.assert.match(error.message, /GCP_STORAGE_SCRAPED_FILE_NAME/)
+        return true
+      }
+    )
+  })
+
+  test('does not put the value of a present variable in the message', t => {
+    const recognisableSecretValue = 'secret-openai-key-never-printed'
+    const environmentMissingScrapedFileName = {
+      ...completeEnvironment,
+      OPENAI_API_KEY: recognisableSecretValue
+    }
+    delete environmentMissingScrapedFileName.GCP_STORAGE_SCRAPED_FILE_NAME
+
+    t.assert.throws(
+      () => validateEnv(environmentMissingScrapedFileName),
+      error => {
+        t.assert.doesNotMatch(
+          error.message,
+          new RegExp(recognisableSecretValue)
+        )
+        t.assert.match(error.message, /GCP_STORAGE_SCRAPED_FILE_NAME/)
+        return true
+      }
+    )
+  })
+})

--- a/packages/embeddings-creation/test/startupValidation.test.js
+++ b/packages/embeddings-creation/test/startupValidation.test.js
@@ -1,0 +1,68 @@
+import { after, before, test, mock } from 'node:test'
+import sinon from 'sinon'
+
+// The point of this file is ordering, not the message: create-embeddings.js
+// builds an OpenAI client and captures both GCP_STORAGE_* file names as it
+// loads, so a validateEnv() call that sat after a static import of it would run
+// too late to stop any of that. index.js therefore validates first and imports
+// create-embeddings.js dynamically, and the assertions below are that the
+// import rejects and that the OpenAI constructor never ran. The functions
+// framework is mocked because index.js imports it statically, so it evaluates
+// before validation and must register nothing real. dotenv/config is
+// neutralised so a developer's local .env cannot decide the outcome, and this
+// package's test script sets the two GCP_STORAGE_* names via cross-env, so they
+// are cleared explicitly below. mock.module registers a specifier once per
+// process, so this lives in its own test file.
+
+const openAiConstructorSpy = sinon.spy()
+const cloudEventSpy = sinon.spy()
+
+class OpenAIMock {
+  constructor(...args) {
+    openAiConstructorSpy(...args)
+  }
+}
+
+const environmentBeforeTest = { ...process.env }
+
+const variablesClearedForTest = [
+  'OPENAI_API_KEY',
+  'GCP_STORAGE_SCRAPED_FILE_NAME',
+  'GCP_STORAGE_EMBEDDING_FILE_NAME'
+]
+
+before(() => {
+  mock.module('dotenv/config', {})
+  mock.module('@google-cloud/functions-framework', {
+    namedExports: { cloudEvent: cloudEventSpy }
+  })
+  mock.module('openai', {
+    defaultExport: OpenAIMock,
+    namedExports: { OpenAI: OpenAIMock }
+  })
+
+  for (const variableName of variablesClearedForTest) {
+    delete process.env[variableName]
+  }
+})
+
+after(() => {
+  process.env = { ...environmentBeforeTest }
+  mock.reset()
+  sinon.restore()
+})
+
+test('loading the embeddings entry point without its environment rejects before the OpenAI client is constructed', async t => {
+  await t.assert.rejects(
+    () => import('../src/index.js'),
+    error => {
+      t.assert.match(error.message, /OPENAI_API_KEY/)
+      t.assert.match(error.message, /GCP_STORAGE_SCRAPED_FILE_NAME/)
+      t.assert.match(error.message, /GCP_STORAGE_EMBEDDING_FILE_NAME/)
+      return true
+    }
+  )
+
+  sinon.assert.notCalled(openAiConstructorSpy)
+  sinon.assert.notCalled(cloudEventSpy)
+})

--- a/packages/slack-bot/AGENTS.md
+++ b/packages/slack-bot/AGENTS.md
@@ -12,13 +12,14 @@ and offers a `summarize` message shortcut for links and files.
 
 | File | Role |
 |---|---|
-| `src/index.js` | Exports `slackBot`, the Express app the function serves. |
+| `src/index.js` | Calls `validateEnv()`, then dynamically imports `bot.js` and exports `slackBot`, the Express app the function serves. |
+| `src/env.js` | `requiredEnvironmentVariables`, `pubSubEnvironmentVariables` and `validateEnv()`, which throws naming every missing variable. |
 | `src/bot.js` | Bolt app, `ExpressReceiver`, the `message` handler, `/healthz`. |
 | `src/messageEvents.js` | Pure predicates deciding which `message` events and files the handler acts on. |
 | `src/getAnswer.js` | Embeddings load/refresh, context assembly, chat completion. |
 | `src/summarize.js` | The `summarize` shortcut for links and file attachments. |
 | `src/utils.js` | `download`, `parseCsv`, `distancesFromEmbeddings`, `downloadAudio`, `transcribe`, `transcriptionText`. |
-| `src/dev.js` | Local Bolt server (`npm run dev`). |
+| `src/dev.js` | Local Bolt server (`npm run dev`); validates and imports `bot.js` the same way `src/index.js` does. |
 
 ## Commands
 
@@ -34,6 +35,20 @@ npm run lint --workspace=slack-bot
 `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`, `OPENAI_API_KEY`, `GCP_PROJECT_ID`,
 `GCP_STORAGE_BUCKET_NAME`, `GCP_STORAGE_EMBEDDING_FILE_NAME`, `GCP_EMBEDDING_SUBSCRIPTION`,
 optional `MAX_CONTEXT_TOKENS` (default 4000), and `IS_LOCAL_ENVIRONMENT` for local runs.
+
+`src/index.js` and `src/dev.js` both call `validateEnv()` before anything else, so a
+missing, empty or whitespace-only value fails startup with every missing name in one
+error instead of an opaque client-library error on the first Slack request. Always
+required: `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`, `OPENAI_API_KEY`,
+`GCP_STORAGE_BUCKET_NAME` and `GCP_STORAGE_EMBEDDING_FILE_NAME`. `GCP_PROJECT_ID` and
+`GCP_EMBEDDING_SUBSCRIPTION` are required only when `IS_LOCAL_ENVIRONMENT` is falsy,
+since they only build the Pub/Sub subscription name and the local environment skips that
+path. `MAX_CONTEXT_TOKENS` is outside `validateEnv` on purpose (optional, with
+`parsePositiveTokenCount` handling it), and `IS_LOCAL_ENVIRONMENT` is not itself
+validated. The dynamic import of `bot.js` is what keeps the check ahead of the
+`ExpressReceiver`, Bolt app and OpenAI client it builds as it loads:
+`test/startupValidation.test.js` pins the ordering, so do not turn it back into a static
+import.
 
 ## Notes for changes
 

--- a/packages/slack-bot/src/dev.js
+++ b/packages/slack-bot/src/dev.js
@@ -1,5 +1,11 @@
 import 'dotenv/config'
-import app from './bot.js'
+import { validateEnv } from './env.js'
+
+validateEnv()
+
+// Dynamic for the same reason as in index.js: bot.js constructs its clients as
+// it loads, so it must not be imported until the environment has been checked.
+const { default: app } = await import('./bot.js')
 
 await app.start(process.env.PORT || 3000)
 console.log(`⚡️ Slack Bolt app is running!`)

--- a/packages/slack-bot/src/env.js
+++ b/packages/slack-bot/src/env.js
@@ -1,0 +1,56 @@
+/**
+ * Every environment variable the bot cannot run without, in any environment,
+ * as set by `.github/workflows/deploy-step.yml`. `MAX_CONTEXT_TOKENS` is not
+ * here on purpose: it is optional and has a default, validated by
+ * `parsePositiveTokenCount` in `getAnswer.js`.
+ */
+export const requiredEnvironmentVariables = [
+  'SLACK_SIGNING_SECRET',
+  'SLACK_BOT_TOKEN',
+  'OPENAI_API_KEY',
+  'GCP_STORAGE_BUCKET_NAME',
+  'GCP_STORAGE_EMBEDDING_FILE_NAME'
+]
+
+/**
+ * The pair used solely to build the Pub/Sub subscription name in
+ * `getAnswer.js`, a path the local environment skips. They are required only
+ * when `IS_LOCAL_ENVIRONMENT` is falsy.
+ */
+export const pubSubEnvironmentVariables = [
+  'GCP_PROJECT_ID',
+  'GCP_EMBEDDING_SUBSCRIPTION'
+]
+
+const isMissing = value =>
+  typeof value !== 'string' || value.trim().length === 0
+
+/**
+ * Fail fast when the bot is misconfigured. Called from the entry point before
+ * the Bolt receiver, the Bolt app and the OpenAI client are constructed, so a
+ * missing variable is named at startup rather than surfacing as an opaque
+ * client-library error on the first Slack request. Every missing name is
+ * reported at once; no value is ever included in the message, because these
+ * are secrets.
+ *
+ * `IS_LOCAL_ENVIRONMENT` is read off the same `env` with the same `Boolean`
+ * semantics `utils.js` uses, so an empty value still means production.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @throws {Error} if any required variable is absent, empty or whitespace-only
+ */
+export function validateEnv(env = process.env) {
+  const isLocalEnvironment = Boolean(env.IS_LOCAL_ENVIRONMENT)
+
+  const namesToCheck = isLocalEnvironment
+    ? requiredEnvironmentVariables
+    : [...requiredEnvironmentVariables, ...pubSubEnvironmentVariables]
+
+  const missing = namesToCheck.filter(name => isMissing(env[name]))
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(', ')}`
+    )
+  }
+}

--- a/packages/slack-bot/src/index.js
+++ b/packages/slack-bot/src/index.js
@@ -1,4 +1,11 @@
 import 'dotenv/config'
-import { expressApp } from './bot.js'
+import { validateEnv } from './env.js'
+
+validateEnv()
+
+// Imported dynamically, and only once the environment has been checked:
+// bot.js builds its Bolt receiver, Bolt app and OpenAI client as it loads, and
+// a static import would evaluate all of that before this file's own body ran.
+const { expressApp } = await import('./bot.js')
 
 export { expressApp as slackBot }

--- a/packages/slack-bot/test/env.test.js
+++ b/packages/slack-bot/test/env.test.js
@@ -1,0 +1,146 @@
+import { describe, test } from 'node:test'
+
+import {
+  requiredEnvironmentVariables,
+  pubSubEnvironmentVariables,
+  validateEnv
+} from '../src/env.js'
+
+const completeProductionEnvironment = {
+  SLACK_SIGNING_SECRET: 'slack-signing-secret-value',
+  SLACK_BOT_TOKEN: 'slack-bot-token-value',
+  OPENAI_API_KEY: 'openai-api-key-value',
+  GCP_STORAGE_BUCKET_NAME: 'bucket-name',
+  GCP_STORAGE_EMBEDDING_FILE_NAME: 'embeddings.csv',
+  GCP_PROJECT_ID: 'project-id',
+  GCP_EMBEDDING_SUBSCRIPTION: 'embedding-subscription'
+}
+
+describe('slack-bot validateEnv', () => {
+  test('returns without throwing when every required variable is present', t => {
+    t.assert.doesNotThrow(() =>
+      validateEnv({ ...completeProductionEnvironment })
+    )
+  })
+
+  test('requires exactly the variables the bot deployment always sets', t => {
+    t.assert.deepStrictEqual(requiredEnvironmentVariables, [
+      'SLACK_SIGNING_SECRET',
+      'SLACK_BOT_TOKEN',
+      'OPENAI_API_KEY',
+      'GCP_STORAGE_BUCKET_NAME',
+      'GCP_STORAGE_EMBEDDING_FILE_NAME'
+    ])
+  })
+
+  test('treats the two Pub/Sub variables as the environment-dependent pair', t => {
+    t.assert.deepStrictEqual(pubSubEnvironmentVariables, [
+      'GCP_PROJECT_ID',
+      'GCP_EMBEDDING_SUBSCRIPTION'
+    ])
+  })
+
+  test('does not require MAX_CONTEXT_TOKENS, which has a default', t => {
+    t.assert.strictEqual(
+      requiredEnvironmentVariables
+        .concat(pubSubEnvironmentVariables)
+        .includes('MAX_CONTEXT_TOKENS'),
+      false
+    )
+  })
+
+  test('names every missing variable in one error, not only the first', t => {
+    const environmentMissingTwoVariables = { ...completeProductionEnvironment }
+    delete environmentMissingTwoVariables.SLACK_SIGNING_SECRET
+    delete environmentMissingTwoVariables.GCP_STORAGE_EMBEDDING_FILE_NAME
+
+    t.assert.throws(
+      () => validateEnv(environmentMissingTwoVariables),
+      error => {
+        t.assert.match(error.message, /SLACK_SIGNING_SECRET/)
+        t.assert.match(error.message, /GCP_STORAGE_EMBEDDING_FILE_NAME/)
+        return true
+      }
+    )
+  })
+
+  test('counts an empty string and a whitespace-only value as missing', t => {
+    t.assert.throws(
+      () =>
+        validateEnv({
+          ...completeProductionEnvironment,
+          SLACK_BOT_TOKEN: '',
+          OPENAI_API_KEY: '   '
+        }),
+      error => {
+        t.assert.match(error.message, /SLACK_BOT_TOKEN/)
+        t.assert.match(error.message, /OPENAI_API_KEY/)
+        return true
+      }
+    )
+  })
+
+  test('does not put the value of a present variable in the message', t => {
+    const recognisableSecretValue = 'secret-signing-secret-never-printed'
+    const environmentMissingBotToken = {
+      ...completeProductionEnvironment,
+      SLACK_SIGNING_SECRET: recognisableSecretValue
+    }
+    delete environmentMissingBotToken.SLACK_BOT_TOKEN
+
+    t.assert.throws(
+      () => validateEnv(environmentMissingBotToken),
+      error => {
+        t.assert.doesNotMatch(
+          error.message,
+          new RegExp(recognisableSecretValue)
+        )
+        t.assert.match(error.message, /SLACK_BOT_TOKEN/)
+        return true
+      }
+    )
+  })
+
+  test('requires the Pub/Sub variables when IS_LOCAL_ENVIRONMENT is unset', t => {
+    const environmentWithoutPubSubVariables = {
+      ...completeProductionEnvironment
+    }
+    delete environmentWithoutPubSubVariables.GCP_PROJECT_ID
+    delete environmentWithoutPubSubVariables.GCP_EMBEDDING_SUBSCRIPTION
+
+    t.assert.throws(
+      () => validateEnv(environmentWithoutPubSubVariables),
+      error => {
+        t.assert.match(error.message, /GCP_PROJECT_ID/)
+        t.assert.match(error.message, /GCP_EMBEDDING_SUBSCRIPTION/)
+        return true
+      }
+    )
+  })
+
+  test('does not require the Pub/Sub variables when IS_LOCAL_ENVIRONMENT is set', t => {
+    const localEnvironmentWithoutPubSubVariables = {
+      ...completeProductionEnvironment,
+      IS_LOCAL_ENVIRONMENT: 'true'
+    }
+    delete localEnvironmentWithoutPubSubVariables.GCP_PROJECT_ID
+    delete localEnvironmentWithoutPubSubVariables.GCP_EMBEDDING_SUBSCRIPTION
+
+    t.assert.doesNotThrow(() =>
+      validateEnv(localEnvironmentWithoutPubSubVariables)
+    )
+  })
+
+  test('still requires the Pub/Sub variables when IS_LOCAL_ENVIRONMENT is empty', t => {
+    const environmentWithEmptyLocalFlag = {
+      ...completeProductionEnvironment,
+      IS_LOCAL_ENVIRONMENT: ''
+    }
+    delete environmentWithEmptyLocalFlag.GCP_PROJECT_ID
+
+    t.assert.throws(
+      () => validateEnv(environmentWithEmptyLocalFlag),
+      /GCP_PROJECT_ID/
+    )
+  })
+})

--- a/packages/slack-bot/test/startupValidation.test.js
+++ b/packages/slack-bot/test/startupValidation.test.js
@@ -1,0 +1,91 @@
+import { after, before, test, mock } from 'node:test'
+import sinon from 'sinon'
+
+// The point of this file is ordering, not the message: bot.js builds an
+// ExpressReceiver, a Bolt App and an OpenAI client as it loads, so a
+// validateEnv() call that sat after a static import of bot.js would run too
+// late to stop them. index.js therefore validates first and imports bot.js
+// dynamically, and the assertions below are that the import rejects and that
+// none of those three constructors ran. dotenv/config is neutralised so a
+// developer's local .env cannot decide the outcome, and mock.module registers a
+// specifier once per process, so this lives in its own test file.
+
+const expressReceiverConstructorSpy = sinon.spy()
+const appConstructorSpy = sinon.spy()
+const openAiConstructorSpy = sinon.spy()
+
+class ExpressReceiverMock {
+  app = { get: () => {} }
+  constructor(...args) {
+    expressReceiverConstructorSpy(...args)
+  }
+}
+
+class AppMock {
+  constructor(...args) {
+    appConstructorSpy(...args)
+  }
+  event() {}
+  shortcut() {}
+  error() {}
+}
+
+class OpenAIMock {
+  constructor(...args) {
+    openAiConstructorSpy(...args)
+  }
+}
+
+const environmentBeforeTest = { ...process.env }
+
+const variablesClearedForTest = [
+  'SLACK_SIGNING_SECRET',
+  'SLACK_BOT_TOKEN',
+  'OPENAI_API_KEY',
+  'GCP_STORAGE_BUCKET_NAME',
+  'GCP_STORAGE_EMBEDDING_FILE_NAME',
+  'GCP_PROJECT_ID',
+  'GCP_EMBEDDING_SUBSCRIPTION',
+  'IS_LOCAL_ENVIRONMENT'
+]
+
+before(() => {
+  mock.module('dotenv/config', {})
+  mock.module('@slack/bolt', {
+    namedExports: { App: AppMock, ExpressReceiver: ExpressReceiverMock }
+  })
+  mock.module('openai', {
+    defaultExport: OpenAIMock,
+    namedExports: { OpenAI: OpenAIMock }
+  })
+
+  for (const variableName of variablesClearedForTest) {
+    delete process.env[variableName]
+  }
+})
+
+after(() => {
+  process.env = { ...environmentBeforeTest }
+  mock.reset()
+  sinon.restore()
+})
+
+test('loading the slack bot entry point without its environment rejects before any client is constructed', async t => {
+  await t.assert.rejects(
+    () => import('../src/index.js'),
+    error => {
+      t.assert.match(error.message, /SLACK_SIGNING_SECRET/)
+      t.assert.match(error.message, /SLACK_BOT_TOKEN/)
+      t.assert.match(error.message, /OPENAI_API_KEY/)
+      t.assert.match(error.message, /GCP_STORAGE_BUCKET_NAME/)
+      t.assert.match(error.message, /GCP_STORAGE_EMBEDDING_FILE_NAME/)
+      t.assert.match(error.message, /GCP_PROJECT_ID/)
+      t.assert.match(error.message, /GCP_EMBEDDING_SUBSCRIPTION/)
+      return true
+    }
+  )
+
+  sinon.assert.notCalled(expressReceiverConstructorSpy)
+  sinon.assert.notCalled(appConstructorSpy)
+  sinon.assert.notCalled(openAiConstructorSpy)
+})


### PR DESCRIPTION
Closes #993

## What changed

Every credential and GCP name variable was read from `process.env` and passed straight to a
client constructor. A misconfigured Cloud Run deployment started cleanly and failed at the
first request with whatever opaque error the client library raised, and since nobody watches
a function start, the person who deployed it was never the person who saw it.

**A `validateEnv` per package.** `packages/crawler/src/env.js`,
`packages/embeddings-creation/src/env.js` and `packages/slack-bot/src/env.js` each export
their required-variable list and a `validateEnv(env = process.env)` that:

- treats absent, empty string and whitespace-only alike (trim, then check);
- collects every missing name and throws one `Error` listing all of them;
- never puts a value in the message, only names;
- takes `env` as a defaultable parameter, so tests pass an object instead of mutating
  `process.env`.

The three are duplicated rather than shared, per AGENTS.md on the per-package utils.

Required sets come from `.github/workflows/deploy-step.yml` rather than the README:

| Package | Requires |
|---|---|
| crawler | `NOTION_TOKEN`, `GCP_STORAGE_BUCKET_NAME`, `GCP_STORAGE_SCRAPED_FILE_NAME` |
| embeddings-creation | `OPENAI_API_KEY`, `GCP_STORAGE_SCRAPED_FILE_NAME`, `GCP_STORAGE_EMBEDDING_FILE_NAME` |
| slack-bot | `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`, `OPENAI_API_KEY`, `GCP_STORAGE_BUCKET_NAME`, `GCP_STORAGE_EMBEDDING_FILE_NAME`, plus `GCP_PROJECT_ID` and `GCP_EMBEDDING_SUBSCRIPTION` when `IS_LOCAL_ENVIRONMENT` is falsy |

The bucket is absent from embeddings-creation on purpose: it arrives on the CloudEvent
(`create-embeddings.js:57`), not from the environment. `MAX_CONTEXT_TOKENS` is untouched,
being optional with a default that `parsePositiveTokenCount` already validates.

**Validation at the entry point, before any client is constructed.** The clients are all
built at module scope, and ESM evaluates an imported module's body before its importer's, so
a `validateEnv()` below a static import would run too late. Each entry point therefore loads
dotenv, validates, and then `await import()`s the app module:
`packages/crawler/src/index.js`, `packages/embeddings-creation/src/index.js`,
`packages/slack-bot/src/index.js` and `packages/slack-bot/src/dev.js`. Nothing in `bot.js`,
`create-embeddings.js`, `notion.js` or `crawl.js` changed, and no export changed, which is
why `test/messageHandler.test.js` and the rest of the existing suite are untouched.

The crawler is the case that pays most: `crawl()` runs the whole Notion crawl in
`fetchData()` and only uses the storage variables afterwards
(`packages/crawler/src/crawl.js:11-14`), so a missing bucket name used to burn a complete
crawl before failing.

## How I satisfied myself it works

Tests first, red before green. `test/env.test.js` in each package covers the happy path, the
required list itself, several missing at once (asserting the message names every one, not
just the first), empty string and whitespace-only, and that a recognisable value set on a
variable that IS present never appears in the message. slack-bot adds the conditional pair
both ways, plus the case that an empty `IS_LOCAL_ENVIRONMENT` still counts as production,
matching `utils.js`'s `Boolean(...)` semantics.

The ordering guarantee, which is the actual defect, is pinned separately in
`packages/slack-bot/test/startupValidation.test.js` and
`packages/crawler/test/startupValidation.test.js`: `dotenv/config` is neutralised so a local
`.env` cannot decide the outcome, the required variables are cleared, and the test asserts
that importing the entry point rejects naming them AND that no client constructor ran.

I checked that test actually discriminates rather than passing vacuously: with
`src/index.js` temporarily reverted to a static `import { expressApp } from './bot.js'`, it
fails on `ExpressReceiverMock` having been constructed with `signingSecret: undefined`. The
crawler equivalent was red the same way before the change, reaching `notion.search` through
`getPages`. Both were then reverted to the real implementation.

The crawler ordering test was worth having and is not flaky: it mocks `@notionhq/client`
only, and asserts both that the `Client` constructor never ran and that no `search` was
issued, `search` being `fetchData`'s first act.

Checks, run per workspace in the order `.github/workflows/ci.yml` uses (lint then test), all
passing:

| Workspace | Lint | Tests |
|---|---|---|
| crawler | clean | 10 pass, 0 fail |
| slack-bot | clean | 116 pass, 0 fail |
| embeddings-creation | clean | 7 pass, 0 fail |

Root `npm run lint` and `npm test` are also clean. Those figures are the runner's own
output; the counts quoted in the docs below were taken from the same runs.

## Documentation

Several documents asserted that nothing was validated, and are corrected rather than
softened:

- `AGENTS.md`: the "No credential is validated before use" security bullet, now describing
  `validateEnv` and pointing new required variables at `requiredEnvironmentVariables`; and
  the test counts in the Testing section.
- `docs/knowledge/architecture/external-integrations.md`: the section is rewritten around
  what is now true, keeping the credential table (its line citations re-verified) and
  explaining the validate-then-import ordering.
- `docs/knowledge/tours/start-here.md`: the rough-edges row for this issue is removed.
- `docs/crawler.md`, `docs/embeddings-creation.md`, `docs/slack-bot.md`: startup validation
  added to Behavior & rules, new acceptance criteria appended (appended, not inserted, so no
  existing criterion is renumbered), config lines, key flows, test counts and related code.
- `docs/knowledge/modules/*.md` and `docs/knowledge/architecture/local-environment-emulation.md`:
  entry-point descriptions, the `IS_LOCAL_ENVIRONMENT` note, and `source_paths`.
- `README.md`: a `GCP_PROJECT_ID` row in the slack-bot table (the deploy workflow has always
  set it, the table never listed it), and a note in each package's env section that a missing
  required variable now fails at startup naming it.
- `docs/knowledge/concepts/test-strategy-module-mocks.md`: the repo-wide test counts.

## Decisions where another option was defensible

- **Conditional Pub/Sub variables rather than always required.** `GCP_PROJECT_ID` and
  `GCP_EMBEDDING_SUBSCRIPTION` only build the subscription name (`getAnswer.js:85`) on a path
  the local environment skips (`getAnswer.js:60`). Requiring them unconditionally would be
  simpler but would stop `make bot-start` for a developer with no Pub/Sub configured, and
  `GCP_PROJECT_ID` was not in the README table at all. `env.js` reads the flag off its own
  `env` argument with `utils.js`'s `Boolean(...)` semantics rather than importing `utils.js`,
  which keeps `env.js` free of module-scope side effects.
- **`crawl()` is still not awaited** in `packages/crawler/src/index.js`, as before. It has
  its own `try`/`catch` and `process.exit(1)`, so awaiting it would change nothing except
  the diff.
- **`source_commit` in the knowledge-note frontmatter is left as it was** and only `updated`
  is bumped: that field records the commit a note was generated against, and I cannot know
  this commit's SHA while writing the note.

## Not done

- Nothing from the agreed scope was skipped, and no test was weakened or reshaped.
- `MAX_CONTEXT_TOKENS` is deliberately left alone, as agreed.
- Nothing was verified by running a `make` target or `gcloud`: those hit Notion, OpenAI, or
  open a public tunnel. The startup path is covered by the two ordering tests instead.
- Unrelated defects the specs already record (the unflushed trailing chunk, the silent
  Pub/Sub reload failure, unpaginated Notion child listing) are untouched and still recorded
  as defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
